### PR TITLE
syntax correction environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - python==3.12
   - pip
-  pip:
+  - pip:
     - vitabel


### PR DESCRIPTION
indent for pip not correct. thus binder crashed