### PR TITLE
Improve robustness of loading ZOLL-json format

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -1461,7 +1461,7 @@ class IntervalLabel(Label):
         else:
             if "alpha" not in base_plotstyle:
                 base_plotstyle["alpha"] = 0.5
-            for (xmin, xmax) in time_index:
+            for xmin, xmax in time_index:
                 artist = plot_axes.axvspan(xmin, xmax, **base_plotstyle)
             artist.set_label(self.name)  # only set legend once
 
@@ -2436,11 +2436,11 @@ class TimeDataCollection:
                 min_input.value = ymin
                 max_input.value = ymax
                 text_labels = ax.findobj(
-                    lambda artist: isinstance(artist, Text) and hasattr(artist, "_from_vitals_label")
+                    lambda artist: isinstance(artist, Text)
+                    and hasattr(artist, "_from_vitals_label")
                 )
                 for artist in text_labels:
                     artist.set_y(ymin + 0.1 * (ymax - ymin))
-
 
         def format_coords(x, y):
             format_string = f"(x, y) = ({x:.2f}, {y:.2f})"

--- a/src/vitabel/utils/loading.py
+++ b/src/vitabel/utils/loading.py
@@ -568,10 +568,15 @@ def read_zolljson_contin(wave_recording_elements, starttime):
             refkey = ekey
         i += 1
     if refkey != "":
+        reference_median = 0
+        if msec_time_dev[refkey]:
+            reference_median = np.median(msec_time_dev[refkey])
+
         for key in msec_time_dev:
-            shift_keys[key] = np.median(msec_time_dev[key]) - np.median(
-                msec_time_dev[refkey]
-            )
+            time_median = 0
+            if msec_time_dev[key]:
+                time_median = np.median(msec_time_dev[key])
+            shift_keys[key] = time_median - reference_median
 
         for key in timeseries_data:
             timeseries_data[key].index = timeseries_data[key].index - pd.Timedelta(


### PR DESCRIPTION
This fixes two errors that appeared somewhat frequently across our data set:

- one where shifting by a difference of medians, computed from an empty list, tainted the timestamps to become all `NaT`s,
- and one where the parsing failed due to the measuring length of a waveform being set to `nan`; these waveforms are now simply skipped.