### PR TITLE
Fix #67 -  UFuncTypeError

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -1336,7 +1336,7 @@ class IntervalLabel(Label):
         """
         interval_start, interval_end = time_data
         if self.is_empty() and isinstance(interval_start, Timestamp):
-            self.time_start = interval_start
+            self.time_start = pd.to_datetime(interval_start)
 
         if self.is_time_absolute():
             interval_start -= self.time_start


### PR DESCRIPTION
Fix #67 : Convert numpy.datetime64 to pandas.Timestamp to avoid UFuncTypeError

Resolved a type mismatch issue by converting NumPy datetime64 to Pandas Timestamp, enabling safe addition with timedelta values without raising UFuncTypeError.