### PR TITLE
Add library version to exported data and check for version mismatch when loading

### DIFF
--- a/src/vitabel/__init__.py
+++ b/src/vitabel/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from importlib.metadata import version, PackageNotFoundError
+
 from vitabel.vitals import Vitals
 from vitabel.timeseries import Channel, Label, IntervalLabel, TimeDataCollection
 
@@ -14,3 +16,10 @@ __all__ = [
 
 logger = logging.getLogger("vitabel")
 logger.setLevel(logging.INFO)
+
+try:
+    __version__ = version("vitabel")
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "unknown"
+    logger.warning("vitabel is not installed. Version information is not available.")

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -8,7 +8,7 @@ import pytest
 
 from pathlib import Path
 
-from vitabel import Vitals
+from vitabel import Vitals, __version__
 from vitabel import Channel, Label, IntervalLabel
 
 
@@ -676,6 +676,9 @@ def test_saving_and_loading(tmpdir):
     cardio_object2 = Vitals()
     cardio_object2.load_data(filepath)
     assert cardio_object.data == cardio_object2.data
+    assert "vitabel version" in cardio_object2.metadata
+    assert cardio_object2.metadata["vitabel version"] == __version__
+
 
 
 def test_create_shock_information_DataFrame():


### PR DESCRIPTION
Only logs a warning in case the loaded version actually mismatches.

Closes #88