### PR TITLE
Fix and improve handling of time offset, allow directly setting offset attribute

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -187,7 +187,7 @@ class TimeSeriesBase:
         self.time_index = time_index + offset
 
         if time_start is not None:
-            time_start = pd.Timestamp(time_start)
+            time_start = pd.Timestamp(time_start) + self.offset
             time_start = time_start.tz_localize(None)
         self.time_start = time_start
 
@@ -237,7 +237,10 @@ class TimeSeriesBase:
         time_unit = time_unit or self.time_unit
         if isinstance(delta_t, numbers.Number):
             delta_t = pd.to_timedelta(delta_t, unit=time_unit)
-        self.time_index += delta_t
+        if self.time_start is not None:
+            self.time_start += delta_t
+        else:
+            self.time_index += delta_t
         self.offset += delta_t
 
     def convert_time_input(self, time_input: Timestamp | Timedelta | float | str):

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -538,13 +538,19 @@ class Channel(TimeSeriesBase):
     def to_dict(self) -> dict[str, Any]:
         """Construct a serializable dictionary that represents
         this channel."""
+        numeric_offset = self.offset / pd.to_timedelta(1, unit=self.time_unit)
+        numeric_time = self.numeric_time() - numeric_offset
+        time_start = self.time_start
+        if time_start is not None:
+            time_start = time_start - self.offset
+
         return {
             "name": self.name,
-            "time_index": self.numeric_time(),
+            "time_index": numeric_time,
             "data": self.data,
-            "time_start": str(self.time_start) if self.time_start is not None else None,
+            "time_start": str(time_start) if time_start is not None else None,
             "time_unit": self.time_unit,
-            "offset": self.offset / pd.to_timedelta(1, unit=self.time_unit),
+            "offset": numeric_offset,
             "labels": [label.to_dict() for label in self.labels],
             "plotstyle": self.plotstyle,
             "metadata": self.metadata,
@@ -993,13 +999,19 @@ class Label(TimeSeriesBase):
 
     def to_dict(self) -> dict[str, Any]:
         """A serialization of the label as a dictionary."""
+        numeric_offset = self.offset / pd.to_timedelta(1, unit=self.time_unit)
+        numeric_time = self.numeric_time() - numeric_offset
+        time_start = self.time_start
+        if time_start is not None:
+            time_start = time_start - self.offset
+
         return {
             "name": self.name,
-            "time_index": self.numeric_time(),
+            "time_index": numeric_time,
             "data": self.data,
-            "time_start": str(self.time_start) if self.time_start is not None else None,
+            "time_start": str(time_start) if time_start is not None else None,
             "time_unit": self.time_unit,
-            "offset": self.offset / pd.to_timedelta(1, unit=self.time_unit),
+            "offset": numeric_offset,
             "is_interval": False,
             "plotstyle": self.plotstyle,
             "metadata": self.metadata,

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -187,7 +187,7 @@ class TimeSeriesBase:
         self.time_index = time_index + offset
 
         if time_start is not None:
-            time_start = pd.Timestamp(time_start) + self.offset
+            time_start = pd.Timestamp(time_start)
             time_start = time_start.tz_localize(None)
         self.time_start = time_start
 
@@ -237,10 +237,7 @@ class TimeSeriesBase:
         time_unit = time_unit or self.time_unit
         if isinstance(delta_t, numbers.Number):
             delta_t = pd.to_timedelta(delta_t, unit=time_unit)
-        if self.time_start is not None:
-            self.time_start += delta_t
-        else:
-            self.time_index += delta_t
+        self.time_index += delta_t
         self.offset += delta_t
 
     def convert_time_input(self, time_input: Timestamp | Timedelta | float | str):
@@ -543,15 +540,12 @@ class Channel(TimeSeriesBase):
         this channel."""
         numeric_offset = self.offset / pd.to_timedelta(1, unit=self.time_unit)
         numeric_time = self.numeric_time() - numeric_offset
-        time_start = self.time_start
-        if time_start is not None:
-            time_start = time_start - self.offset
 
         return {
             "name": self.name,
             "time_index": numeric_time,
             "data": self.data,
-            "time_start": str(time_start) if time_start is not None else None,
+            "time_start": str(self.time_start) if self.time_start is not None else None,
             "time_unit": self.time_unit,
             "offset": numeric_offset,
             "labels": [label.to_dict() for label in self.labels],
@@ -1004,15 +998,12 @@ class Label(TimeSeriesBase):
         """A serialization of the label as a dictionary."""
         numeric_offset = self.offset / pd.to_timedelta(1, unit=self.time_unit)
         numeric_time = self.numeric_time() - numeric_offset
-        time_start = self.time_start
-        if time_start is not None:
-            time_start = time_start - self.offset
 
         return {
             "name": self.name,
             "time_index": numeric_time,
             "data": self.data,
-            "time_start": str(time_start) if time_start is not None else None,
+            "time_start": str(self.time_start) if self.time_start is not None else None,
             "time_unit": self.time_unit,
             "offset": numeric_offset,
             "is_interval": False,

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -175,6 +175,20 @@ def test_timeseriesbase_absolute_offset(time_offset):
     np.testing.assert_array_equal(ts.numeric_time(), np.arange(0, 10, 0.5) + 60)
 
 
+def test_timeseriesbase_offset_property():
+    ts = TimeSeriesBase(
+        time_index=np.arange(0, 10, 0.5),
+        time_unit="s",
+    )
+    assert ts.offset.total_seconds() == 0
+
+    ts.offset = pd.Timedelta("1min")
+    np.testing.assert_array_equal(ts.numeric_time(), np.arange(0, 10, 0.5) + 60)
+
+    ts.offset += pd.Timedelta("30s")
+    np.testing.assert_array_equal(ts.numeric_time(), np.arange(0, 10, 0.5) + 90)
+
+
 def test_timeseriesbase_shift_index():
     time = np.arange(0, 10, 0.5)
     ts = TimeSeriesBase(

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -164,6 +164,17 @@ def test_timeseriesbase_offset(time_offset):
     np.testing.assert_array_equal(ts.numeric_time(), np.arange(0, 10, 0.5) + 60)
 
 
+@pytest.mark.parametrize("time_offset", [60, pd.Timedelta("1min")])
+def test_timeseriesbase_absolute_offset(time_offset):
+    ts = TimeSeriesBase(
+        time_index=np.arange(0, 10, 0.5),
+        time_unit="s",
+        time_start=pd.Timestamp("2020-02-02 12:00:00"),
+        offset=time_offset,
+    )
+    np.testing.assert_array_equal(ts.numeric_time(), np.arange(0, 10, 0.5) + 60)
+
+
 def test_timeseriesbase_shift_index():
     time = np.arange(0, 10, 0.5)
     ts = TimeSeriesBase(

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -679,7 +679,30 @@ def test_saving_and_loading(tmpdir):
     assert "vitabel version" in cardio_object2.metadata
     assert cardio_object2.metadata["vitabel version"] == __version__
 
+def test_saving_and_loading_with_offset(tmpdir):
+    channel = Channel(
+        "Channel1",
+        [
+            "2020-04-13 02:48:00",
+            "2020-04-13 02:50:00",
+            "2020-04-13 02:56:00",
+        ],
+        np.array([1, 2, 3]),
+    )
+    channel.shift_time_index(pd.Timedelta("1 hour"))
+    assert channel.time_start == pd.Timestamp(2020, 4, 13, 3, 48, 0)
+    assert channel.offset == pd.Timedelta("1 hour")
+    vital_case = Vitals()
+    vital_case.add_channel(channel)
+    filepath = tmpdir / "testdata.json"
+    vital_case.save_data(filepath)
 
+    loaded_case = Vitals()
+    loaded_case.load_data(filepath)
+    loaded_channel = loaded_case.get_channel("Channel1")
+    assert loaded_channel.time_start == pd.Timestamp(2020, 4, 13, 3, 48, 0)
+    assert loaded_channel.offset == pd.Timedelta("1 hour")
+    assert vital_case.data == loaded_case.data
 
 def test_create_shock_information_DataFrame():
     shock_energie = Channel(

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -690,8 +690,9 @@ def test_saving_and_loading_with_offset(tmpdir):
         np.array([1, 2, 3]),
     )
     channel.shift_time_index(pd.Timedelta("1 hour"))
-    assert channel.time_start == pd.Timestamp(2020, 4, 13, 3, 48, 0)
+    assert channel.time_start == pd.Timestamp(2020, 4, 13, 2, 48, 0)
     assert channel.offset == pd.Timedelta("1 hour")
+    assert channel.get_data()[0][0] == pd.Timestamp(2020, 4, 13, 3, 48, 0)
     vital_case = Vitals()
     vital_case.add_channel(channel)
     filepath = tmpdir / "testdata.json"
@@ -700,8 +701,9 @@ def test_saving_and_loading_with_offset(tmpdir):
     loaded_case = Vitals()
     loaded_case.load_data(filepath)
     loaded_channel = loaded_case.get_channel("Channel1")
-    assert loaded_channel.time_start == pd.Timestamp(2020, 4, 13, 3, 48, 0)
+    assert loaded_channel.time_start == pd.Timestamp(2020, 4, 13, 2, 48, 0)
     assert loaded_channel.offset == pd.Timedelta("1 hour")
+    assert loaded_channel.get_data()[0][0] == pd.Timestamp(2020, 4, 13, 3, 48, 0)
     assert vital_case.data == loaded_case.data
 
 def test_create_shock_information_DataFrame():


### PR DESCRIPTION
This fixes issues where the time offset was not handled correctly when saving / loading our data structure. `TimeSeriesBase.offset` is also changed to be a computed property with a proper setter function, such that modifying the offset attribute properly applies the time shift to the time index.

Fixes #110.