### PR TITLE
Fix IntervalLabel.from_dict to ignore vline_text_source and other irr…

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -1703,6 +1703,50 @@ class IntervalLabel(Label):
         )
         return truncated_label
 
+    @classmethod
+    def from_dict(cls, datadict: dict[str, Any]) -> Label:
+        """Create a IntervalLabel from a serialized dictionary representation.
+
+        Parameters
+        ----------
+        datadict
+            The dictionary representation of the label.
+
+        """
+        if not datadict.get("is_interval", False):
+            raise ValueError("Cannot create IntervalLabel from non-interval label data")
+
+        time_index = datadict.get("time_index")
+        try:
+            time_index = decompress_array(time_index)
+        except (TypeError, ValueError, EOFError):
+            pass
+
+        data = datadict.get("data")
+        try:
+            data = decompress_array(data)
+        except (TypeError, ValueError, EOFError):
+            pass
+
+        text_data = datadict.get("text_data")
+        try:
+            text_data = decompress_array(text_data)
+        except (TypeError, ValueError, EOFError):
+            pass
+
+        return cls(
+            name=datadict.get("name"),
+            time_index=time_index,
+            data=data,
+            text_data=text_data,
+            time_start=datadict.get("time_start"),
+            time_unit=datadict.get("time_unit"),
+            offset=datadict.get("offset"),
+            plotstyle=datadict.get("plotstyle"),
+            metadata=datadict.get("metadata"),
+            plot_type=datadict.get("plot_type"),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """A serialization of the label as a dictionary."""
         label_dict = super().to_dict()

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -685,6 +685,44 @@ def test_interval_label_get_data():
         pd.Timestamp(stmp) for stmp in ["2020-02-03 14:42:00", "2020-02-03 18:00:00"]
     )
 
+def test_interval_label_to_dict_and_from_dict():
+    # Create an IntervalLabel instance
+    label = IntervalLabel(
+        name="Test Interval",
+        time_index=np.array([
+            pd.Timestamp("2020-02-02 12:00:00"),
+            pd.Timestamp("2020-02-02 12:45:00"),
+            pd.Timestamp("2020-02-03 14:42:00"),
+            pd.Timestamp("2020-02-03 18:00:00"),
+            pd.Timestamp("2020-02-03 18:42:00"),
+            pd.Timestamp("2020-02-03 19:00:57"),                             
+        ]),
+        data=np.array([10, 20, 30]),
+        text_data=[None,"a", None],
+        time_unit="s",
+        offset=0,
+        plotstyle={"color": "red"},
+        metadata={"foo": "bar"},
+        plot_type="box"
+    )
+
+    # Serialize to dict
+    d = label.to_dict()
+
+    # Restore from dict
+    restored = IntervalLabel.from_dict(d)
+
+    # Check that fields match
+    assert restored.name == label.name
+    assert np.all(restored.time_index == label.time_index)
+    assert np.all(restored.data == label.data)
+    assert restored.time_start == label.time_start
+    assert restored.time_unit == label.time_unit
+    assert restored.offset == label.offset
+    assert restored.plotstyle == label.plotstyle
+    assert restored.metadata == label.metadata
+    assert restored.plot_type == label.plot_type
+
 
 def test_empty_collection():
     collection = TimeDataCollection()


### PR DESCRIPTION
Fix IntervalLabel.from_dict to ignore vline_text_source and other irrelevant keys
- Prevents TypeError when restoring IntervalLabel from dicts containing keys only valid for Label.
- Ensures IntervalLabel.from_dict only passes valid arguments to its constructor.

Add test for IntervalLabel to_dict and from_dict round-trip

fixes #169 