### PR TITLE
Refactor input to `area_under_threshold` in form of new `source` argument

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -452,7 +452,7 @@ class Channel(TimeSeriesBase):
         plotstyle: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
     ):
-        self.name = name
+        self.name = str(name)
         """The name of the channel."""
 
         self.labels = []
@@ -774,7 +774,7 @@ class Channel(TimeSeriesBase):
         new_name
             The new name of the channel.
         """
-        self.name = new_name
+        self.name = str(new_name)
 
 
 # TODO: handling of name, data, plotstyle, metadata is
@@ -870,7 +870,7 @@ class Label(TimeSeriesBase):
         plot_type: LabelPlotType | None = None,
         vline_text_source: LabelPlotVLineTextSource | None = None, 
     ):
-        self.name = name
+        self.name = str(name)
         """The name of the label."""
 
         self.anchored_channel: Channel | None = None

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -1848,7 +1848,10 @@ class Vitals:
         ----------
         name
             The name of the label or channel - retrieved by meth:`.get_channel_or_label`.
-            Allowed to be passed either as a positional or a keyword argument.
+            Cannot be used together with `channel_or_label`.
+        channel_or_label
+            The `Channel` or `Label` object to calculate the area under threshold for.
+            Cannot be used together with `name`.
         start_time
             Start time for truncating the timeseries (meth:`truncate).
             If ``None``, starts from the beginning.

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -1869,7 +1869,7 @@ class Vitals:
             stop_time = self.rec_stop()
 
         if isinstance(source, str):
-            source = self.get_channel_or_label(name)
+            source = self.get_channel_or_label(source)
 
         if not isinstance(source, (Channel, Label)):
             raise ValueError(

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -1826,7 +1826,8 @@ class Vitals:
 
     def area_under_threshold(
         self,
-        name: str,
+        name: str | None = None,
+        channel_or_label: Channel | Label | None = None,
         start_time: Timestamp | Timedelta | None = None,
         stop_time: Timestamp | Timedelta | None = None,
         threshold: int = 0
@@ -1867,7 +1868,27 @@ class Vitals:
         if stop_time is None:
             stop_time = self.rec_stop()
 
-        index, data = self.get_channel_or_label(name).get_data()
+        if name and channel_or_label:
+            raise TypeError(
+                "Cannot specify both 'name' and 'channel_or_label'. "
+                "Please use only one of them."
+            )
+        
+        if name is None and channel_or_label is None:
+            raise ValueError(
+                "Either 'name' or 'channel_or_label' must be specified. "
+                "Please provide one of them."
+            )
+        
+        if name is not None:
+            channel_or_label = self.get_channel_or_label(name)
+
+        if not isinstance(channel_or_label, (Channel, Label)):
+            raise TypeError(
+                "The 'channel_or_label' argument must be a Channel or Label instance, "
+            )
+        
+        index, data, *_ = channel_or_label.get_data()
         timeseries = pd.Series(data, index=index)
 
         return helpers.area_under_threshold(

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -1007,18 +1007,18 @@ def test_area_under_threshold_computation():
             ]).transpose(),
         )
     )
-    threshold_metric = vital_case.area_under_threshold(name=0, threshold=10)
+    threshold_metric = vital_case.area_under_threshold(source="0", threshold=10)
     assert threshold_metric.duration_under_threshold == pd.Timedelta(0)
     assert threshold_metric.time_weighted_average_under_threshold.value == 0
 
-    threshold_metric = vital_case.area_under_threshold(name=0, threshold=100)
+    threshold_metric = vital_case.area_under_threshold(source="0", threshold=100)
     assert threshold_metric.duration_under_threshold == pd.Timedelta(2, unit="h")
     assert threshold_metric.time_weighted_average_under_threshold.value == 100 - 42
     assert threshold_metric.observational_interval_duration == pd.Timedelta(2, unit="h")
     assert threshold_metric.area_under_threshold.unit == "minutes × value units"
     assert threshold_metric.area_under_threshold.value == (100 - 42) * 60 * 2
 
-    threshold_metric = vital_case.area_under_threshold(name=1, threshold=0)
+    threshold_metric = vital_case.area_under_threshold(source="1", threshold=0)
     assert threshold_metric.observational_interval_duration == pd.Timedelta(2, unit="h")
     assert threshold_metric.duration_under_threshold == pd.Timedelta("01:00:00.000000001")
 


### PR DESCRIPTION
enhancement: ``added channel_or_label``as parameter to ``area_under_threshold``

Therefore in case of ambigous names the cahnnel or label can be specified.

solves #174