### PR TITLE
Add `Vitals.detach_label_from_channel` as dedicated way of using data container to manage label attachments

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -529,6 +529,14 @@ class Channel(TimeSeriesBase):
     def detach_label(self, label: Label):
         """Detach a label from this channel.
 
+        .. note::
+
+            This method only removes the reference from the channel
+            to the label, as well as the backreference from the label
+            to the channel. While this does not delete the label
+            object itself, the responsibility to manage the label
+            object is with the user.
+
         Parameters
         ----------
         label
@@ -1338,11 +1346,20 @@ class Label(TimeSeriesBase):
         self.anchored_channel = channel
 
     def detach(self):
-        """Detach the label from the channel."""
+        """Detach the label from the channel.
+        
+        .. note::
+
+            This method only removes the reference from the channel
+            to the label, as well as the backreference from the label
+            to the channel. While this does not delete the label
+            object itself, the responsibility to manage the label
+            object is with the user.
+        
+        """
         if self.anchored_channel is None:
             raise ValueError(f"The label {self.name} is not attached to any channel")
         self.anchored_channel.detach_label(self)
-        self.anchored_channel = None
 
     def get_data(
         self,

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -544,6 +544,7 @@ class Channel(TimeSeriesBase):
         """
         if label not in self.labels:
             raise ValueError(f"The label {label.name} is not attached to this channel")
+        label.anchored_channel = None
         self.labels.remove(label)
 
     def shift_time_index(

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -2292,6 +2292,39 @@ class TimeDataCollection:
             )
         self.global_labels.append(label)
 
+    def detach_label_from_channel(
+        self,
+        *,
+        label: Label | str,
+        channel: Channel | str,
+        reattach_as_global: bool = True,
+    ) -> Label:
+        """Detach a label from a channel in the collection.
+        
+        Parameters
+        ----------
+        label
+            The label to detach. Can be specified either as a
+            :class:`.Label` object or by its name.
+        channel
+            The channel to detach the label from. Can be specified
+            either as a :class:`.Channel` object or by its name.
+        reattach_as_global
+            If ``True``, the label is reattached as a global label
+            after detaching it from the channel. If ``False``, the
+            label is removed from the collection.
+        """
+        if isinstance(label, str):
+            label = self.get_label(name=label)
+        if isinstance(channel, str):
+            channel = self.get_channel(name=channel)
+
+        channel.detach_label(label)
+        if reattach_as_global:
+            self.add_global_label(label)
+
+        return label
+
     def get_channels(self, name: str | None = None, **kwargs) -> list[Channel]:
         """Return a list of channels.
 

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -903,6 +903,34 @@ class Vitals:
     def keys(self) -> list[str]:
         """Alias for :meth:`get_channel_or_label_names`."""
         return self.get_channel_or_label_names()
+    
+    def detach_label_from_channel(
+        self,
+        *,
+        label: Label | str,
+        channel: Channel | str,
+        reattach_as_global: bool = True,
+    ) -> Label:
+        """Detach a label from a channel in the collection.
+        
+        Parameters
+        ----------
+        label
+            The label to detach. Can be specified either as a
+            :class:`.Label` object or by its name.
+        channel
+            The channel to detach the label from. Can be specified
+            either as a :class:`.Channel` object or by its name.
+        reattach_as_global
+            If ``True``, the label is reattached as a global label
+            after detaching it from the channel. If ``False``, the
+            label is removed from the collection.
+        """
+        return self.data.detach_label_from_channel(
+            label=label,
+            channel=channel,
+            reattach_as_global=reattach_as_global
+        )
 
     def rec_start(self) -> pd.Timestamp | None:  # part of register application
         """Returns the first timestamp among all channels in this case or None if no channel exists."""

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -849,6 +849,31 @@ def test_collection_add_local_label_as_global():
         collection.add_global_label(label)
 
 
+def test_collection_detach_label_from_channel():
+    time = np.arange(0, 1, 0.1)
+    data = np.sin(2 * np.pi * time)
+    channel = Channel(name="test", time_index=time, data=data)
+    label1 = Label(name="events1", time_index=[0.5, 0.7, 0.9])
+    label2 = Label(name="events2", time_index=[0.1, 0.2, 0.3])
+    channel.attach_label(label1)
+    channel.attach_label(label2)
+
+    collection = TimeDataCollection(channels=[channel])
+    assert len(collection.local_labels) == 2
+
+    collection.detach_label_from_channel(label=label1, channel=channel)
+    assert label1 not in channel.labels
+    assert len(collection.local_labels) == 1
+    assert label1.anchored_channel is None
+    assert label1 in collection.global_labels
+
+    collection.detach_label_from_channel(label=label2, channel=channel, reattach_as_global=False)
+    assert label2 not in channel.labels
+    assert len(collection.local_labels) == 0
+    assert label2.anchored_channel is None
+    assert len(collection.global_labels) == 1
+
+
 def test_collection_label_time_type_mismatch():
     time = np.arange(0, 1, 0.1)
     data = np.sin(2 * np.pi * time)


### PR DESCRIPTION
Resolves #112 