### PR TITLE
Make interactive plot checkbox menu population more robust 

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -3117,7 +3117,9 @@ class TimeDataCollection:
         delete_toggle_button.observe(delete_toggle_handler, names="value")
 
         label_dropdown.observe(label_dropdown_change, names="value")
-        _populate_label_add_menu(label_dict[label_dropdown.value])
+
+        if label_dropdown.value in label_dict:
+            _populate_label_add_menu(label_dict[label_dropdown.value])
 
 
         # ---------- WIDGETS FOR SHIFTING ------------------------


### PR DESCRIPTION
Resolves #179 

Fixes the initialization of an interactive plot in case there are no labels in the given collection.