### PR TITLE
Fix repainting of overview indicators after changes to overview plot

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -3338,6 +3338,7 @@ class TimeDataCollection:
             return
 
         def repaint_overview_plot():
+            nonlocal overview_indicators
             channels_for_xlims = channel_lists
             for channel_list, subax in zip(channel_overviews, overview_axes):
                 if not channel_list:
@@ -3356,6 +3357,7 @@ class TimeDataCollection:
                 data_width = (ov_stop - ov_start).total_seconds()
                 resolution = data_width / screen_pixel_width
                 subax.clear()
+                overview_indicators = []
                 for channel in channel_list:
                     channel.plot(
                         plot_axes=subax,


### PR DESCRIPTION
Resolves #181 

This was due to us attempting to remove artists from a figure when they actually were already cleared by the function that repaints the overview plot.