### PR TITLE
Add auxiliary data structure `DataSlice` holding the output of `Channel.get_data` / `Label.get_data`

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -562,9 +562,11 @@ class Channel(TimeSeriesBase):
             The stop time for the truncated channel.
         """
 
-        truncated_time_index, truncated_data = self.get_data(
+        channel_data = self.get_data(
             start=start_time, stop=stop_time
         )
+        truncated_time_index = channel_data.time_index
+        truncated_data = channel_data.data
         # if channel is absolute time, the truncated time index is absolute,
         # no need to set start_time. also, offset is applied to the truncated
         # time index.
@@ -621,17 +623,17 @@ class Channel(TimeSeriesBase):
             data ends at the last time point.
         """
        
-        time_index, data = self.get_data(start=start, stop=stop)
+        channel_data = self.get_data(start=start, stop=stop)
         if filename is None:
             filename = f"{self.name}.csv"
         
         if isinstance(filename, str):
             filename = Path(filename)
 
-        if data is None:
-            df = pd.DataFrame({"time": time_index})
+        if channel_data.data is None:
+            df = pd.DataFrame({"time": channel_data.time_index})
         else:
-            df = pd.DataFrame({"time": time_index, "data": data})
+            df = pd.DataFrame({"time": channel_data.time_index, "data": channel_data.data})
         df.to_csv(filename)
 
     @classmethod
@@ -739,7 +741,9 @@ class Channel(TimeSeriesBase):
             (the default), the time unit of the channel is used.
         """
 
-        time_index, data = self.get_data(start=start, stop=stop, resolution=resolution)
+        channel_data = self.get_data(start=start, stop=stop, resolution=resolution)
+        time_index = channel_data.time_index
+        data = channel_data.data
         if data is None:
             data = np.zeros_like(time_index, dtype=float)
 
@@ -1258,9 +1262,12 @@ class Label(TimeSeriesBase):
         stop_time
             The stop time for the truncated label.
         """
-        truncated_time_index, truncated_data, truncated_text_data = self.get_data(
+        label_data = self.get_data(
             start=start_time, stop=stop_time
         )
+        truncated_time_index = label_data.time_index
+        truncated_data = label_data.data
+        truncated_text_data = label_data.text_data
 
         truncated_label = Label(
             name=self.name,
@@ -3516,10 +3523,10 @@ class TimeDataCollection:
                                     / screen_pixel_width
                                     * CANVAS_SELECTION_TOLERANCE_PX
                                 )
-                                selected_times, _, _ = active_label.get_data(
+                                selected_times = active_label.get_data(
                                     start=time_data - tolerance,
                                     stop=time_data + tolerance,
-                                )
+                                ).time_index
                                 if len(selected_times) > 0:
                                     selected_time = min(selected_times)
                                     active_label.remove_data(time_data=selected_time)

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -29,7 +29,8 @@ from vitabel.typing import (
     Timestamp,
     ChannelSpecification,
     LabelSpecification,
-    LabelAnnotationPresetType
+    LabelAnnotationPresetType,
+    DataSlice,
 )
 
 
@@ -675,7 +676,7 @@ class Channel(TimeSeriesBase):
         start: Timestamp | Timedelta | float | None = None,
         stop: Timestamp | Timedelta | float | None = None,
         resolution: Timedelta | float | str | None = None,
-    ) -> tuple[npt.NDArray, npt.NDArray | None]:
+    ) -> DataSlice:
         """Return a tuple of time and data values with optional
         filtering and downsampling.
 
@@ -702,7 +703,7 @@ class Channel(TimeSeriesBase):
             time_index += self.time_start
 
         data = self.data[time_mask] if self.data is not None else None
-        return time_index, data
+        return DataSlice(time_index=time_index, data=data)
 
     def plot(
         self,
@@ -1394,7 +1395,7 @@ class Label(TimeSeriesBase):
         self,
         start: Timestamp | Timedelta | float | None = None,
         stop: Timestamp | Timedelta | float | None = None,
-    ) -> tuple[npt.NDArray, npt.NDArray | None, npt.NDArray | None]:
+    ) -> DataSlice:
         """Return a tuple of time, data, and text data values with optional
         filtering.
 
@@ -1422,7 +1423,7 @@ class Label(TimeSeriesBase):
         if self.text_data is not None and time_mask.any():
             text_data = self.text_data[time_mask]
 
-        return time_index, data, text_data
+        return DataSlice(time_index=time_index, data=data, text_data=text_data)
 
     def plot(
         self,
@@ -1879,7 +1880,7 @@ class IntervalLabel(Label):
         self,
         start: Timestamp | Timedelta | float | None = None,
         stop: Timestamp | Timedelta | float | None = None,
-    ) -> tuple[npt.NDArray, npt.NDArray | None]:
+    ) -> DataSlice:
         """Return a tuple of interval endpoints and data values with optional
         filtering. This returns all intervals that intersect with the
         specified time range, shortening the intervals if necessary.
@@ -1894,7 +1895,7 @@ class IntervalLabel(Label):
             data ends at the last time point.
         """
         if self.is_empty() or (start is None and stop is None):
-            return self.intervals, self.data, self.text_data
+            return DataSlice(time_index=self.intervals, data=self.data, text_data=self.text_data)
 
         if start is None:
             start = self.time_index.min()
@@ -1921,7 +1922,7 @@ class IntervalLabel(Label):
         data = None if data is not None and len(data) == 0 else data
         text_data = None if text_data is not None and len(text_data) == 0 else text_data
 
-        return intervals, data, text_data
+        return DataSlice(time_index=intervals, data=data, text_data=text_data)
     
 
     def add_data(

--- a/src/vitabel/typing.py
+++ b/src/vitabel/typing.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 
 from dataclasses import dataclass
-from typing import Any, Union, TypeAlias, Literal, Iterable, TYPE_CHECKING
+from typing import Any, Union, TypeAlias, Literal, Iterator, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vitabel import Channel, Label
@@ -93,5 +93,5 @@ class DataSlice:
     def __len__(self) -> int:
         return len(self.time_index)
     
-    def __iter__(self) -> Iterable:
+    def __iter__(self) -> Iterator:
         return iter((self.time_index, self.data, self.text_data))

--- a/src/vitabel/typing.py
+++ b/src/vitabel/typing.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 
 from dataclasses import dataclass
-from typing import Any, Union, TypeAlias, Literal, TYPE_CHECKING
+from typing import Any, Union, TypeAlias, Literal, Iterable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vitabel import Channel, Label
@@ -68,3 +68,30 @@ class ThresholdMetrics:
     duration_under_threshold: pd.Timedelta
     time_weighted_average_under_threshold: Metric
     observational_interval_duration: pd.Timedelta
+
+
+@dataclass
+class DataSlice:
+    """Auxiliary dataclass holding a slice of data from a label or channel.
+    
+    Primarily used in the various ``get_data`` methods.
+    """
+
+    time_index: pd.DatetimeIndex | pd.TimedeltaIndex | np.typing.NDArray
+    """The time index of the selected data range."""
+
+    data: np.typing.NDArray | None = None
+    """The data of the selected data range, or ``None`` if no data
+    is available.
+    """
+
+    text_data: np.typing.NDArray | None = None
+    """The text data of the selected data range, or ``None`` if no text data
+    is available.
+    """
+    
+    def __len__(self) -> int:
+        return len(self.time_index)
+    
+    def __iter__(self) -> Iterable:
+        return iter((self.time_index, self.data, self.text_data))

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -1126,7 +1126,8 @@ class Vitals:
 
         for channel in self.channels:
             if channel.name in defib_channel_names:
-                time, data = channel.get_data()
+                channel_data = channel.get_data()
+                time, data = channel_data.time_index, channel_data.data
                 defib_data[channel.name] = {"timestamp": time, "data": data}
 
         time_index = np.array([])
@@ -1200,7 +1201,8 @@ class Vitals:
             )
         else:
             co2_channel = self.data.get_channel("capnography")
-            cotime, co = co2_channel.get_data()  # get data
+            co2_data = co2_channel.get_data()  # get data
+            cotime, co = co2_data.time_index, co2_data.data
 
             freq = np.timedelta64(1, "s") / np.nanmedian(cotime.diff())
             cotime = np.asarray(cotime)
@@ -1438,7 +1440,7 @@ class Vitals:
 
 
             
-        comp, *_ = cc_events_channel.get_data() # get data
+        comp = cc_events_channel.get_data().time_index # get data
 
         t_ref = cc_events_channel.time_start
 
@@ -1543,7 +1545,8 @@ class Vitals:
         else:
             ACC_channel = accelerometer_channel
 
-        acctime, acc = ACC_channel.get_data()  # get data
+        acc_data = ACC_channel.get_data()  # get data
+        acctime, acc = acc_data.time_index, acc_data.data
         freq = np.timedelta64(1, "s") / np.nanmedian(acctime.diff())
         t_ref = ACC_channel.time_start
 
@@ -1751,16 +1754,18 @@ class Vitals:
             )
         else:
             ACC_channel = self.data.get_channel("cpr_acceleration")
-            acctime, acc = ACC_channel.get_data()  # get data
+            acc_data = ACC_channel.get_data()  # get data
+            acctime, acc = acc_data.time_index, acc_data.data
 
             ECG_channel = self.data.get_channel("ecg_pads")
-            ecgtime, ecg = ECG_channel.get_data()  # get data
+            ecg_data = ECG_channel.get_data()  # get data
+            ecgtime, ecg = ecg_data.time_index, ecg_data.data
 
             if "cc_periods" not in self.get_label_names():
                 self.find_CC_periods_acc()
  
             label_cc_periods = self.data.get_label("cc_periods")
-            cc_periods, *_ = label_cc_periods.get_data()
+            cc_periods = label_cc_periods.get_data().time_index
             cc_periods =  np.asarray([t for pair in cc_periods for t in pair])
 
             t_ref = ACC_channel.time_start
@@ -1878,8 +1883,8 @@ class Vitals:
                 "Channel or Label"
             )
         
-        index, data, *_ = source.get_data()
-        timeseries = pd.Series(data, index=index)
+        source_data = source.get_data()
+        timeseries = pd.Series(source_data.data, index=source_data.time_index)
 
         return helpers.area_under_threshold(
             timeseries=timeseries,

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -294,25 +294,26 @@ def test_channel_get_data():
     channel = Channel(name="test", time_index=time, data=data)
     time_channel = Channel(name="test timeonly", time_index=time, data=None)
 
-    x, y = channel.get_data()
-    np.testing.assert_allclose(x.total_seconds(), time)
-    np.testing.assert_allclose(y, data)
+    dt = channel.get_data()
+    np.testing.assert_allclose(dt.time_index.total_seconds(), time)
+    np.testing.assert_allclose(dt.data, data)
 
-    x, y = time_channel.get_data()
-    np.testing.assert_allclose(x.total_seconds(), time)
-    assert y is None
+    dt = time_channel.get_data()
+    np.testing.assert_allclose(dt.time_index.total_seconds(), time)
+    assert dt.data is None
+    assert dt.text_data is None
 
-    x, y = channel.get_data(start=1.5, stop=3.5)
-    np.testing.assert_allclose(x.total_seconds(), time[15:36])
-    np.testing.assert_allclose(y, data[15:36])
+    dt = channel.get_data(start=1.5, stop=3.5)
+    np.testing.assert_allclose(dt.time_index.total_seconds(), time[15:36])
+    np.testing.assert_allclose(dt.data, data[15:36])
 
-    x, y = channel.get_data(start=1.0, stop=4.0, resolution="0.5s")
-    np.testing.assert_allclose(x.total_seconds(), np.arange(1.0, 4.01, 0.5))
-    np.testing.assert_allclose(y, 0, atol=1e-8)
+    dt = channel.get_data(start=1.0, stop=4.0, resolution="0.5s")
+    np.testing.assert_allclose(dt.time_index.total_seconds(), np.arange(1.0, 4.01, 0.5))
+    np.testing.assert_allclose(dt.data, 0, atol=1e-8)
 
-    x, y = channel.get_data(start=1.0, stop=4.0, resolution=1.0)
-    np.testing.assert_allclose(x.total_seconds(), np.arange(1.0, 4.01, 1.0))
-    np.testing.assert_allclose(y, 0, atol=1e-8)
+    dt = channel.get_data(start=1.0, stop=4.0, resolution=1.0)
+    np.testing.assert_allclose(dt.time_index.total_seconds(), np.arange(1.0, 4.01, 1.0))
+    np.testing.assert_allclose(dt.data, 0, atol=1e-8)
 
 
 def test_channel_get_data_absolute():
@@ -320,12 +321,12 @@ def test_channel_get_data_absolute():
     data = np.random.random(len(time))
     channel = Channel(name="test", time_index=time, data=data)
 
-    x, y = channel.get_data(
+    dt = channel.get_data(
         start=pd.Timestamp("2020-02-02 12:02:30"),
         stop=pd.Timestamp("2020-02-02 12:05:00"),
     )
-    assert np.all(x == time[25:51])
-    np.testing.assert_allclose(y, data[25:51])
+    assert np.all(dt.time_index == time[25:51])
+    np.testing.assert_allclose(dt.data, data[25:51])
 
 
 def test_channel_get_data_invalid_bounds():
@@ -667,19 +668,19 @@ def test_interval_label_get_data():
         name="rainfall",
         time_index=time_index,
     )
-    t, _, _ = label.get_data()
+    t = label.get_data().time_index
     assert len(t) == 2
     assert tuple(t[0]) == tuple(
         pd.Timestamp(stmp) for stmp in ["2020-02-02 12:00:00", "2020-02-02 12:45:00"]
     )
 
-    t, _, _ = label.get_data(start=pd.Timestamp("2020-02-03 14:00:00"))
+    t = label.get_data(start=pd.Timestamp("2020-02-03 14:00:00")).time_index
     assert len(t) == 1
     assert tuple(t[0]) == tuple(
         pd.Timestamp(stmp) for stmp in ["2020-02-03 14:42:00", "2020-02-03 18:00:00"]
     )
 
-    t, _, _ = label.get_data(start=pd.Timestamp("2020-02-03 15:00:00"))
+    t = label.get_data(start=pd.Timestamp("2020-02-03 15:00:00")).time_index
     assert len(t) == 1
     assert tuple(t[0]) == tuple(
         pd.Timestamp(stmp) for stmp in ["2020-02-03 14:42:00", "2020-02-03 18:00:00"]

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -632,9 +632,9 @@ def test_truncate():
     case.add_global_label(lab)
     truncated_case = case.truncate("2020-04-13 02:49:30", "2020-04-13 02:57:00")
     assert len(truncated_case.channels[0]) == 2
-    ch_time, _ = truncated_case.channels[0].get_data()
-    assert np.all(pd.Timestamp("2020-04-13 02:49:30") <= ch_time)
-    assert np.all(pd.Timestamp("2020-04-13 02:57:00") >= ch_time)
+    channel_data = truncated_case.channels[0].get_data()
+    assert np.all(pd.Timestamp("2020-04-13 02:49:30") <= channel_data.time_index)
+    assert np.all(pd.Timestamp("2020-04-13 02:57:00") >= channel_data.time_index)
     assert len(truncated_case.labels) == 2
     local_label = truncated_case.get_label("local label")
     assert len(local_label) == 1
@@ -692,7 +692,7 @@ def test_saving_and_loading_with_offset(tmpdir):
     channel.shift_time_index(pd.Timedelta("1 hour"))
     assert channel.time_start == pd.Timestamp(2020, 4, 13, 2, 48, 0)
     assert channel.offset == pd.Timedelta("1 hour")
-    assert channel.get_data()[0][0] == pd.Timestamp(2020, 4, 13, 3, 48, 0)
+    assert channel.get_data().time_index[0] == pd.Timestamp(2020, 4, 13, 3, 48, 0)
     vital_case = Vitals()
     vital_case.add_channel(channel)
     filepath = tmpdir / "testdata.json"
@@ -703,7 +703,7 @@ def test_saving_and_loading_with_offset(tmpdir):
     loaded_channel = loaded_case.get_channel("Channel1")
     assert loaded_channel.time_start == pd.Timestamp(2020, 4, 13, 2, 48, 0)
     assert loaded_channel.offset == pd.Timedelta("1 hour")
-    assert loaded_channel.get_data()[0][0] == pd.Timestamp(2020, 4, 13, 3, 48, 0)
+    assert loaded_channel.get_data().time_index[0] == pd.Timestamp(2020, 4, 13, 3, 48, 0)
     assert vital_case.data == loaded_case.data
 
 def test_create_shock_information_DataFrame():


### PR DESCRIPTION
The current implementation in form of a wrapper `DataSlice` object is somewhat more readable, while still allowing the previous "unpacking pattern" for the sake of convenience, i.e.,

```py
time_index, data, text_data = source.get_data()
```

As the interface (and the number of returned items in the slice) might change at some point, it is highly recommended to use something along the lines of

```py
dt = source.get_data()
dt.time_index
dt.data
dt.text_data
```

instead, which is stable.

Resolves #107 