### PR TITLE
fix: checked for empty channels before rasining inconsistency Error

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -2365,6 +2365,7 @@ class TimeDataCollection:
             )
         if (
             not self.is_empty()
+            and not channel.is_empty() # empty channel will always be relative
             and self.is_time_absolute() != channel.is_time_absolute()
         ):
             raise ValueError(


### PR DESCRIPTION
added additional check for empty channels, as the always will be relative time_index due to start_time being None

resolves #199