### PR TITLE
harmonizations channel label operations, especially adding filtering

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -2312,35 +2312,12 @@ class TimeDataCollection:
     def channel_names(self) -> list[str]:
         """List of channel names."""
         return [channel.name for channel in self.channels]
-    
-    def get_channel_names(self, **kwargs) -> list[str]:
-        """Return a list of channel names.
-
-        Parameters
-        ----------
-        kwargs
-            Keyword arguments to filter the channels by. The
-            specified arguments are compared to the attributes
-            of the channels.
-        """
-        return [channel.name for channel in self.get_channels(**kwargs)]    
 
     @property
     def label_names(self) -> list[str]:
         """List of label names for all labels in the collection."""
         return [label.name for label in self.labels]
-    
-    def get_label_names(self, **kwargs) -> list[str]:
-        """Return a list of label names.
 
-        Parameters
-        ----------
-        kwargs
-            Keyword arguments to filter the labels by. The
-            specified arguments are compared to the attributes
-            of the labels.
-        """
-        return [label.name for label in self.get_labels(**kwargs)]
 
     def is_empty(self) -> bool:
         """Return whether the collection is empty."""

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -2312,11 +2312,35 @@ class TimeDataCollection:
     def channel_names(self) -> list[str]:
         """List of channel names."""
         return [channel.name for channel in self.channels]
+    
+    def get_channel_names(self, **kwargs) -> list[str]:
+        """Return a list of channel names.
+
+        Parameters
+        ----------
+        kwargs
+            Keyword arguments to filter the channels by. The
+            specified arguments are compared to the attributes
+            of the channels.
+        """
+        return [channel.name for channel in self.get_channels(**kwargs)]    
 
     @property
     def label_names(self) -> list[str]:
         """List of label names for all labels in the collection."""
         return [label.name for label in self.labels]
+    
+    def get_label_names(self, **kwargs) -> list[str]:
+        """Return a list of label names.
+
+        Parameters
+        ----------
+        kwargs
+            Keyword arguments to filter the labels by. The
+            specified arguments are compared to the attributes
+            of the labels.
+        """
+        return [label.name for label in self.get_labels(**kwargs)]
 
     def is_empty(self) -> bool:
         """Return whether the collection is empty."""

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -2308,17 +2308,6 @@ class TimeDataCollection:
         """All labels in the collection, both global and local ones."""
         return self.global_labels + self.local_labels
 
-    @property
-    def channel_names(self) -> list[str]:
-        """List of channel names."""
-        return [channel.name for channel in self.channels]
-
-    @property
-    def label_names(self) -> list[str]:
-        """List of label names for all labels in the collection."""
-        return [label.name for label in self.labels]
-
-
     def is_empty(self) -> bool:
         """Return whether the collection is empty."""
         return not self.channels and not self.global_labels

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -870,7 +870,7 @@ class Vitals:
 
         Parameters
         ----------
-        name : str
+        name
             The name of the channels to retrieve.
         kwargs
             Keyword arguments to filter the channels by.
@@ -888,7 +888,7 @@ class Vitals:
 
         Parameters
         ----------
-        name : str
+        name
             The name of the channel to retrieve.
         kwargs
             Keyword arguments to filter the channels by.
@@ -903,7 +903,6 @@ class Vitals:
         -------
         Channel
             The channel that matches the specification.
-            If no channel matches the specification, an empty list is returned.
         """
 
         return self.data.get_channel(name, **kwargs)
@@ -951,21 +950,22 @@ class Vitals:
     ) -> list[Channel | Label]:
         """Returns a list of channels or labels based on their name.
 
-        This method combines the results of :meth:`.get_channel` and :meth:`.
-        get_label` to return both channels and labels that match the given name.
+        This method combines the results of :meth:`.get_channels` and :meth:`.
+        get_labels` to return both channels and labels that match the given parameters.
         If a `label_type` is specified, it filters the labels accordingly.
 
 
         Parameters
         ----------
-        name : str
+        name
             The name of the channels or labels to retrieve.
-            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.   
-        label_type : TYPE, optional
-            A specification of the label type (IntervalLabel or Label) to retrieve.
+            See :meth:`.get_channels` and :meth:`.get_labels` for valid specifications.   
+        label_type
+            The class of the labels (e.g., :class:`.IntervalLabel`) to
+            retrieve.
         kwargs  
             Keyword arguments to filter the channels or labels by.
-            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
+            See :meth:`.get_channels` and :meth:`.get_labels` for valid specifications.
 
         Returns
         -------
@@ -985,11 +985,12 @@ class Vitals:
 
         Parameters
         ----------
-        name : str
+        name
             The name of the channel or label to retrieve.
             See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
-        label_type : TYPE, optional
-            A specification of the label type (IntervalLabel or Label) to retrieve.
+        label_type
+            The class of the label (e.g., :class:`.IntervalLabel`) to
+            retrieve.
         kwargs
             Keyword arguments to filter the channels or labels by.
             See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
@@ -1004,7 +1005,6 @@ class Vitals:
         -------
         Channel | Label
             The channel or label that matches the specification.
-            If no channel or label matches the specification, an empty list is returned.
         """
 
         channels_or_labels = self.get_channels_or_labels(name, label_type=label_type, **kwargs)
@@ -1141,7 +1141,7 @@ class Vitals:
         ----------
         kwargs
             Keyword arguments to filter the channels by.
-            See :meth:`.get_channel` for valid specifications.
+            See :meth:`.get_channels` for valid specifications.
 
         Returns
         -------
@@ -1166,7 +1166,7 @@ class Vitals:
         ----------
         kwargs
             Keyword arguments to filter the labels by.
-            See :meth:`.get_label` for valid specifications.
+            See :meth:`.get_labels` for valid specifications.
 
         Returns
         -------

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -952,7 +952,7 @@ class Vitals:
 
         This method combines the results of :meth:`.get_channels` and :meth:`.
         get_labels` to return both channels and labels that match the given parameters.
-        If a `label_type` is specified, it filters the labels accordingly.
+        If a ``label_type`` is specified, it filters the labels accordingly.
 
 
         Parameters

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -865,12 +865,12 @@ class Vitals:
     def get_channels(self, name: str | None = None, **kwargs) -> list[Channel]:
         """Returns a list of channels based on their name.
 
+        This method retrieves all channels that match the given name and
+        keyword arguments. If no name is specified, all channels are returned.
+
         See also
         --------
         :meth:`.TimeDataCollection.get_channels`
-        -----------
-        This method retrieves all channels that match the given name and
-        keyword arguments. If no name is specified, all channels are returned.
 
         Parameters
         ----------
@@ -893,8 +893,7 @@ class Vitals:
         See also
         --------
         :meth:`.TimeDataCollection.get_channel`
-        -----------
-        This method retrieves a single channel that matches the given name.
+
 
         Parameters
         ----------
@@ -924,9 +923,6 @@ class Vitals:
         See also
         --------
         :meth:`.TimeDataCollection.get_labels`
-        -----------
-        This method retrieves all labels that match the given name and
-        keyword arguments. If no name is specified, all labels are returned.
         
         Parameters
         ----------
@@ -971,15 +967,15 @@ class Vitals:
         self, name: str | None = None, label_type: type[Label] | None = None,  **kwargs
     ) -> list[Channel | Label]:
         """Returns a list of channels or labels based on their name.
-        
-        See also
-        --------
-        :meth:`.get_channel` and :meth:`.get_label`
-        -----------
 
         This method combines the results of :meth:`.get_channel` and :meth:`.
         get_label` to return both channels and labels that match the given name.
         If a `label_type` is specified, it filters the labels accordingly.
+        
+        See also
+        --------
+        :meth:`.get_channel` and :meth:`.get_label`
+
 
         Parameters
         ----------
@@ -1011,10 +1007,6 @@ class Vitals:
         See also
         --------
         :meth:`.get_channel` and :meth:`.get_label`
-        -----------
-        This method combines the results of :meth:`.get_channel` and :meth:`.get_label`
-        to return a single channel or label that matches the given name.
-        If a `label_type` is specified, it filters the labels accordingly.
 
         Parameters
         ----------
@@ -2084,7 +2076,6 @@ class Vitals:
 
         See also
         --------
-        
         :func:`.utils.helpers.area_under_threshold`
 
         Parameters

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -1030,26 +1030,46 @@ class Vitals:
             If no channel matches the specification, an empty list is returned.
         """
 
-        if kwargs:
-            channel_names = self.data.get_channel_names(**kwargs)
-        else:
-            channel_names = self.data.channel_names
-            
-        return channel_names
+        channels = self.data.get_channels(**kwargs)
+        
+        return [channel.name for channel in channels]
 
     def get_label_names(self, **kwargs) -> list[str]:  # part of register application
         """Returns a list with the names of all labels.
+
+        Parameters
+        ----------
+        kwargs
+            Keyword arguments to filter the labels by.
+            See :meth:`.get_label` for valid specifications.
+
+        Returns
+        -------
+        list[str]
+            A list with the names of all labels in the recording.
+            If no label matches the specification, an empty list is returned.
         
         """
-        if kwargs:
-            label_names = self.data.get_label_names(**kwargs)
-        else:
-            label_names = self.data.label_names
 
-        return label_names
+        labels = self.data.get_labels(**kwargs)
+        
+        return [label.name for label in labels]
 
     def get_channel_or_label_names(self, **kwargs) -> list[str]:
-        """Returns a list with all names from either channels or labels."""
+        """Returns a list with all names from either channels or labels.
+        
+        Parameters
+        ----------
+        kwargs
+            Keyword arguments to filter the channels and labels by.
+            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
+
+        Returns
+        -------
+        list[str]
+            A list with the names of all channels and labels in the recording.
+            If no channel or label matches the specification, an empty list is returned.
+        """
         return self.get_channel_names(**kwargs) + self.get_label_names(**kwargs)
 
     def keys(self, **kwargs) -> list[str]:

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -863,24 +863,85 @@ class Vitals:
     # ----------------------------------------------- Retrieve data -------------------------------------------------------------------------------------------------
     # ---------------------------------------------------------------------------------------------------------------------------------------------
     def get_channels(self, name: str | None = None, **kwargs) -> list[Channel]:
+        """Returns a list of channels based on their name.
+
+        See also
+        --------
+        :meth:`.TimeDataCollection.get_channels`
+        -----------
+        This method retrieves all channels that match the given name and
+        keyword arguments. If no name is specified, all channels are returned.
+
+        Parameters
+        ----------
+        name : str
+            The name of the channels to retrieve.
+        kwargs
+            Keyword arguments to filter the channels by.
+
+        Returns
+        -------
+        list[Channel]
+            A list of channels that match the specification.
+            If no channel matches the specification, an empty list is returned.
+        """
         return self.data.get_channels(name, **kwargs)
 
     def get_channel(self, name: str | None = None, **kwargs) -> Channel:
+        """Returns a single channel based on its name.
+
+        See also
+        --------
+        :meth:`.TimeDataCollection.get_channel`
+        -----------
+        This method retrieves a single channel that matches the given name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the channel to retrieve.
+        kwargs
+            Keyword arguments to filter the channels by.
+
+        Raises
+        ------
+        ValueError
+            If the specification is ambiguous, i.e., if more than one channel
+            matches the specification.
+
+        Returns
+        -------
+        Channel
+            The channel that matches the specification.
+            If no channel matches the specification, an empty list is returned.
+        """
+
         return self.data.get_channel(name, **kwargs)
 
     def get_labels(self, name: str | None = None, label_type: type[Label] | None = None, **kwargs) -> list[Label]:
         """Returns a list of labels based on their name.
+
+        See also
+        --------
+        :meth:`.TimeDataCollection.get_labels`
+        -----------
+        This method retrieves all labels that match the given name and
+        keyword arguments. If no name is specified, all labels are returned.
         
         Parameters
         ----------
         name : str
             The name of the labels to retrieve.
-            See :meth:`.get_label` for valid specifications.
         label_type : TYPE, optional
             A specification of the label type (IntervalLabel or Label) to retrieve
         kwargs
             Keyword arguments to filter the labels by. 
-            See :meth:`.get_label` for valid specifications
+
+        Returns
+        -------
+        list[Label]
+            A list of labels that match the specification.
+            If no label matches the specification, an empty list is returned.
         """
 
         if label_type is not None:
@@ -909,6 +970,35 @@ class Vitals:
     def get_channels_or_labels(
         self, name: str | None = None, label_type: type[Label] | None = None,  **kwargs
     ) -> list[Channel | Label]:
+        """Returns a list of channels or labels based on their name.
+        
+        See also
+        --------
+        :meth:`.get_channel` and :meth:`.get_label`
+        -----------
+
+        This method combines the results of :meth:`.get_channel` and :meth:`.
+        get_label` to return both channels and labels that match the given name.
+        If a `label_type` is specified, it filters the labels accordingly.
+
+        Parameters
+        ----------
+        name : str
+            The name of the channels or labels to retrieve.
+            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.   
+        label_type : TYPE, optional
+            A specification of the label type (IntervalLabel or Label) to retrieve.
+        kwargs  
+            Keyword arguments to filter the channels or labels by.
+            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
+
+        Returns
+        -------
+        list[Channel | Label]
+            A list of channels or labels that match the specification.
+            If no channel or label matches the specification, an empty list is returned.
+
+        """
         return self.data.get_channels(name, **kwargs) + self.get_labels(
             name, label_type=label_type, **kwargs
         )
@@ -916,6 +1006,40 @@ class Vitals:
     def get_channel_or_label(
         self, name: str | None = None, label_type: type[Label] | None = None, **kwargs
     ) -> Channel | Label:
+        """Returns a single channel or label based on its name.
+
+        See also
+        --------
+        :meth:`.get_channel` and :meth:`.get_label`
+        -----------
+        This method combines the results of :meth:`.get_channel` and :meth:`.get_label`
+        to return a single channel or label that matches the given name.
+        If a `label_type` is specified, it filters the labels accordingly.
+
+        Parameters
+        ----------
+        name : str
+            The name of the channel or label to retrieve.
+            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
+        label_type : TYPE, optional
+            A specification of the label type (IntervalLabel or Label) to retrieve.
+        kwargs
+            Keyword arguments to filter the channels or labels by.
+            See :meth:`.get_channel` and :meth:`.get_label` for valid specifications.
+
+        Raises  
+        ------
+        ValueError
+            If the specification is ambiguous, i.e., if more than one channel or label
+            matches the specification.
+
+        Returns
+        -------
+        Channel | Label
+            The channel or label that matches the specification.
+            If no channel or label matches the specification, an empty list is returned.
+        """
+
         channels_or_labels = self.get_channels_or_labels(name, label_type=label_type, **kwargs)
         if len(channels_or_labels) != 1:
             raise ValueError(
@@ -965,21 +1089,59 @@ class Vitals:
                     stop_time = cha_stop_time
         return stop_time
 
-    def get_channel_infos(self) -> pd.DataFrame:
+    def get_channel_infos(self, **kwargs) -> pd.DataFrame:
         """Returns information about all channels in a nicely formatted
-        ``pandas.DataFrame``.
+        ``pandas.DataFrame``.   
+        This includes the channel name, number of datapoints, first entry, last entry, offset, auxiliary metadata.
+        Parameters
+        ----------
+        kwargs
+            Keyword arguments to filter the channels by.
+            See :meth:`.get_channel` for valid specifications.
+        Returns
+        -------
+        pd.DataFrame
+            A DataFrame containing the channel information.
+        The DataFrame contains the following columns:
+        - ``Name``: The name of the channel.
+        - ``Length``: The number of data points in the channel.
+        - ``First Entry``: The first timestamp of the channel.
+        - ``Last Entry``: The last timestamp of the channel.
+        - ``Offset``: The offset of the channel, i.e., the time difference
+        - ``metadata``: All auxillary metadata of the channel.
         """
         return _timeseries_list_info(self.channels)
 
-    def get_label_infos(self) -> pd.DataFrame:
+    def get_label_infos(self, **kwargs) -> pd.DataFrame:
         """Returns information about all labels in a nicely formatted
         ``pandas.DataFrame``.
+        This includes the label name, number of datapoints, first entry, last entry, offset, auxiliary metadata.
+        Parameters
+        ----------
+        kwargs
+            Keyword arguments to filter the labels by.
+            See :meth:`.get_label` for valid specifications.
+        Returns
+        -------
+        pd.DataFrame
+            A DataFrame containing the label information.
+        The DataFrame contains the following columns:
+        - ``Name``: The name of the label.
+        - ``Length``: The number of data points in the label.
+        - ``First Entry``: The first timestamp of the label.
+        - ``Last Entry``: The last timestamp of the label.
+        - ``Offset``: The offset of the label, i.e., the time difference
+        - ``metadata``: All auxillary metadata of the label.
         """
         return _timeseries_list_info(self.labels)
 
     def info(self) -> None:
         """Displays relevant information about the channels and labels
-        currently present in the recording.
+        currently present in the recording in two separate
+        ``pandas.DataFrame``s.
+        See also
+        --------
+        :meth:`get_channel_infos` and :meth:`get_label_infos`
         """
         channel_info = self.get_channel_infos()
         label_info = self.get_label_infos()

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -950,8 +950,9 @@ class Vitals:
     ) -> list[Channel | Label]:
         """Returns a list of channels or labels based on their name.
 
-        This method combines the results of :meth:`.get_channels` and :meth:`.
-        get_labels` to return both channels and labels that match the given parameters.
+        This method combines the results of :meth:`.get_channels` 
+        and :meth:`.get_labels` to return both channels and labels
+        that match the given parameters.
         If a ``label_type`` is specified, it filters the labels accordingly.
 
 

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -868,10 +868,6 @@ class Vitals:
         This method retrieves all channels that match the given name and
         keyword arguments. If no name is specified, all channels are returned.
 
-        See also
-        --------
-        :meth:`.TimeDataCollection.get_channels`
-
         Parameters
         ----------
         name : str
@@ -889,11 +885,6 @@ class Vitals:
 
     def get_channel(self, name: str | None = None, **kwargs) -> Channel:
         """Returns a single channel based on its name.
-
-        See also
-        --------
-        :meth:`.TimeDataCollection.get_channel`
-
 
         Parameters
         ----------
@@ -919,10 +910,6 @@ class Vitals:
 
     def get_labels(self, name: str | None = None, label_type: type[Label] | None = None, **kwargs) -> list[Label]:
         """Returns a list of labels based on their name.
-
-        See also
-        --------
-        :meth:`.TimeDataCollection.get_labels`
         
         Parameters
         ----------
@@ -947,10 +934,6 @@ class Vitals:
     def get_label(self, name: str | None = None, **kwargs) -> Label:
         """Return a list of labels.
 
-        See also
-        --------
-        :meth:`.TimeDataCollection.get_label`
-
         Parameters
         ----------
         name
@@ -971,10 +954,6 @@ class Vitals:
         This method combines the results of :meth:`.get_channel` and :meth:`.
         get_label` to return both channels and labels that match the given name.
         If a `label_type` is specified, it filters the labels accordingly.
-        
-        See also
-        --------
-        :meth:`.get_channel` and :meth:`.get_label`
 
 
         Parameters
@@ -1003,10 +982,6 @@ class Vitals:
         self, name: str | None = None, label_type: type[Label] | None = None, **kwargs
     ) -> Channel | Label:
         """Returns a single channel or label based on its name.
-
-        See also
-        --------
-        :meth:`.get_channel` and :meth:`.get_label`
 
         Parameters
         ----------
@@ -1160,10 +1135,6 @@ class Vitals:
         """Displays relevant information about the channels and labels
         currently present in the recording in two separate
         ``pandas.DataFrame``s.
-
-        See also
-        --------
-        :meth:`get_channel_infos` and :meth:`get_label_infos`
 
         Parameters
         ----------

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -752,13 +752,14 @@ def test_add_and_remove_channel(data_time_2ecg):
     collection.add_channel(channel2)
 
     assert len(collection.channels) == 2
-    assert collection.channel_names == ["ECG 1", "ECG 2"]
+    channels = collection.channels
+    assert [channel.name for channel in channels] == ["ECG 1", "ECG 2"]
 
     collection.remove_channel(name="ECG 1")
 
     assert len(collection.channels) == 1
-    assert collection.channel_names == ["ECG 2"]
-
+    channels = collection.channels
+    assert [channel.name for channel in channels] == ["ECG 2"]
 
 def test_collection_incompatible_time_types():
     time = np.arange(0, 1, 0.1)
@@ -801,7 +802,8 @@ def test_collection_with_local_and_global_labels():
     new_label = Label(name="local 2", time_index=[0.1, 0.3, 0.5])
     channel.attach_label(new_label)
     assert len(collection.local_labels) == 2
-    assert collection.label_names == ["global 1", "global 2", "local 1", "local 2"]
+    labels = collection.labels
+    assert [label.name for label in labels] == ["global 1", "global 2", "local 1", "local 2"]
 
     collection.remove_label(name="global 1")
     assert len(collection.global_labels) == 1
@@ -896,13 +898,15 @@ def test_remove_label():
 
     collection = TimeDataCollection(channels=[channel], labels=[label, label2])
     assert len(collection.labels) == 2
-    assert collection.label_names == ["events", "events 2"]
+    labels = collection.labels
+    assert [label.name for label in labels] == ["events", "events 2"]
 
     events_label = collection.remove_label(name="events")
     assert events_label is label
     assert events_label not in collection.labels
     assert len(collection.labels) == 1
-    assert collection.label_names == ["events 2"]
+    labels = collection.labels
+    assert [label.name for label in labels] == ["events 2"]
 
     with pytest.raises(ValueError, match="ambiguous"):
         collection.remove_label(name="nonexistent")
@@ -919,7 +923,8 @@ def test_delete_nonexistent_channel():
     collection.add_channel(Channel(name="test", time_index=time, data=data))
 
     assert len(collection.channels) == 1
-    assert collection.channel_names == ["test"]
+    channels = collection.channels
+    assert [channel.name for channel in channels] == ["test"]
 
     with pytest.raises(ValueError) as exc:
         collection.remove_channel(name="nonexistent")
@@ -1109,7 +1114,9 @@ def test_serialization():
     cloned_collection = TimeDataCollection.from_dict(json.loads(serialized_collection))
 
     assert collection.channel_data_hash() == cloned_collection.channel_data_hash()
-    assert collection.label_names == cloned_collection.label_names
+    collection_labels = collection.labels
+    cloned_collection_labels = cloned_collection.labels
+    assert [label.name for label in collection_labels] == [label.name for label in cloned_collection_labels]
 
 def test_to_csv(tmpdir):
     collection = get_random_collection(


### PR DESCRIPTION
- [x] refactor: added kwargs to channel / label operations in vitaly.py
- [x] refactor: removed property ``label_names`` and ``channel_names`` in timeseries.py 
- [x] ehanced: docstrings
- [ ] explcitly integrate channel numbering as ``ìnfo`` with ``kwargs`` can't provide this infroamtion

resolves #208