### PR TITLE
Unify input arguments and checks for automatic analysis / computation methods

### DIFF
--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -1462,6 +1462,7 @@ class Vitals:
 
     def compute_etco2_and_ventilations(
         self,
+        source: Channel | str = "capnography",
         mode: Literal['threshold', 'filter'] = 'filter',
         breath_threshold: float = 2,
         etco2_threshold: float = 3,
@@ -1500,50 +1501,79 @@ class Vitals:
                 "use breath_threshold instead"
             )
 
-        if "capnography" not in self.get_channel_names():
-            logger.error(
-                "Error! No Capnography Signal found. Cannot compute etCO₂ and detect ventilations"
+        if isinstance(source, str):
+            source = self.get_channel(name=source)
+
+        if not isinstance(source, Channel):
+            raise ValueError(
+                f"No valid capnography channel specified. Please make sure a channel named '{source}' "
+                "is added to the collection, or specify a suitable channel via "
+                "the source argument directly or by name"
             )
-        else:
-            co2_channel = self.data.get_channel("capnography")
-            co2_data = co2_channel.get_data()  # get data
-            cotime, co = co2_data.time_index, co2_data.data
 
-            freq = np.timedelta64(1, "s") / np.nanmedian(cotime.diff())
-            cotime = np.asarray(cotime)
-            co = np.asarray(co)
-            if mode == "filter":  # Wolfgang Kern's unpublished method
-                but = sgn.butter(4, 1 * 2 / freq, btype="lowpass", output="sos")
-                co2 = sgn.sosfiltfilt(but, co)  # Filter forwarsd and backward
-                et_index = sgn.find_peaks(co2, distance=1 * freq, height=etco2_threshold)[
-                    0
-                ]  # find peaks of filtered signal as markers for etco2
-                resp_index = sgn.find_peaks(
-                    -co2, distance=1 * freq, height=-breath_threshold
-                )[  # find dips of filtered signal as markers for ventilations
-                    0
+        co2_data = source.get_data()  # get data
+        cotime, co = co2_data.time_index, co2_data.data
+
+        freq = np.timedelta64(1, "s") / np.nanmedian(cotime.diff())
+        cotime = np.asarray(cotime)
+        co = np.asarray(co)
+        if mode == "filter":  # Wolfgang Kern's unpublished method
+            but = sgn.butter(4, 1 * 2 / freq, btype="lowpass", output="sos")
+            co2 = sgn.sosfiltfilt(but, co)  # Filter forwarsd and backward
+            et_index = sgn.find_peaks(co2, distance=1 * freq, height=etco2_threshold)[
+                0
+            ]  # find peaks of filtered signal as markers for etco2
+            resp_index = sgn.find_peaks(
+                -co2, distance=1 * freq, height=-breath_threshold
+            )[  # find dips of filtered signal as markers for ventilations
+                0
+            ]
+
+            etco2time = cotime[et_index]  # take elements on this markers
+            etco2 = co[et_index]
+            resptime = cotime[resp_index]
+            resp_height = co[resp_index]
+
+            # initialize search for other markers
+            k = 0
+            del_resp = []
+            more_resp_flag = False
+            min_resp_height = np.nan
+            min_resp_index = np.nan
+
+            # look a signal before first ventilation
+
+            co2_maxtime = etco2time[(etco2time < resptime[0])]
+            co2_max = etco2[(etco2time < resptime[0])]
+            netco2 = len(co2_maxtime)
+
+            # when there is more than a single maximum before first respiration, take only largest one
+            if netco2 > 1:
+                k_max = np.argmax(co2_max)
+                for j in range(k + k_max, k, -1):
+                    etco2 = np.delete(etco2, k)
+                    etco2time = np.delete(etco2time, k)
+                for j in range(k + netco2, k + k_max + 1, -1):
+                    etco2 = np.delete(etco2, k + 1)
+                    etco2time = np.delete(etco2time, k + 1)
+                k += 1
+
+            # if there is no maximum
+            elif netco2 == 0:
+                pass
+            # if there is a single maximum
+            else:
+                k += 1
+
+            for i, resp in enumerate(resptime[:-1]):
+                next_resp = resptime[i + 1]
+                # check maxima until next respiration same as bevfore
+                co2_maxtime = etco2time[
+                    (etco2time >= resp) & (etco2time < next_resp)
                 ]
-
-                etco2time = cotime[et_index]  # take elements on this markers
-                etco2 = co[et_index]
-                resptime = cotime[resp_index]
-                resp_height = co[resp_index]
-
-                # initialize search for other markers
-                k = 0
-                del_resp = []
-                more_resp_flag = False
-                min_resp_height = np.nan
-                min_resp_index = np.nan
-
-                # look a signal before first ventilation
-
-                co2_maxtime = etco2time[(etco2time < resptime[0])]
-                co2_max = etco2[(etco2time < resptime[0])]
+                co2_max = etco2[(etco2time >= resp) & (etco2time < next_resp)]
                 netco2 = len(co2_maxtime)
-
-                # when there is more than a single maximum before first respiration, take only largest one
-                if netco2 > 1:
+                if netco2 > 1:  # take largest one
                     k_max = np.argmax(co2_max)
                     for j in range(k + k_max, k, -1):
                         etco2 = np.delete(etco2, k)
@@ -1552,154 +1582,129 @@ class Vitals:
                         etco2 = np.delete(etco2, k + 1)
                         etco2time = np.delete(etco2time, k + 1)
                     k += 1
-
-                # if there is no maximum
+                    more_resp_flag = False
                 elif netco2 == 0:
-                    pass
-                # if there is a single maximum
+                    if more_resp_flag:
+                        if resp_height[i] > min_resp_height:
+                            del_resp.append(i)
+                        else:
+                            del_resp.append(min_resp_index)
+                            min_resp_height = resp_height[i]
+                    else:
+                        if resp_height[i] > resp_height[i + 1]:
+                            del_resp.append(i)
+                            min_resp_height = resp_height[i + 1]
+                            min_resp_index = i + 1
+
+                            more_resp_flag = True
+                        else:
+                            del_resp.append(i + 1)
+                            min_resp_height = resp_height[i]
+                            min_resp_index = i
+                            more_resp_flag = True
+
                 else:
+                    more_resp_flag = False
                     k += 1
 
-                for i, resp in enumerate(resptime[:-1]):
-                    next_resp = resptime[i + 1]
-                    # check maxima until next respiration same as bevfore
-                    co2_maxtime = etco2time[
-                        (etco2time >= resp) & (etco2time < next_resp)
-                    ]
-                    co2_max = etco2[(etco2time >= resp) & (etco2time < next_resp)]
-                    netco2 = len(co2_maxtime)
-                    if netco2 > 1:  # take largest one
-                        k_max = np.argmax(co2_max)
-                        for j in range(k + k_max, k, -1):
-                            etco2 = np.delete(etco2, k)
-                            etco2time = np.delete(etco2time, k)
-                        for j in range(k + netco2, k + k_max + 1, -1):
-                            etco2 = np.delete(etco2, k + 1)
-                            etco2time = np.delete(etco2time, k + 1)
-                        k += 1
-                        more_resp_flag = False
-                    elif netco2 == 0:
-                        if more_resp_flag:
-                            if resp_height[i] > min_resp_height:
-                                del_resp.append(i)
-                            else:
-                                del_resp.append(min_resp_index)
-                                min_resp_height = resp_height[i]
-                        else:
-                            if resp_height[i] > resp_height[i + 1]:
-                                del_resp.append(i)
-                                min_resp_height = resp_height[i + 1]
-                                min_resp_index = i + 1
+            del_resp.sort()
+            for i in del_resp[::-1]:
+                resptime = np.delete(resptime, i)
 
-                                more_resp_flag = True
-                            else:
-                                del_resp.append(i + 1)
-                                min_resp_height = resp_height[i]
-                                min_resp_index = i
-                                more_resp_flag = True
+        elif mode == "threshold":   # Aramendi et al., 2016
+            but = sgn.butter(4, 10 * 2 / freq, btype="lowpass", output="sos")
+            co2 = sgn.sosfiltfilt(but, co)  # Filter forwarsd and backward
+            d = freq * (co2[1:] - co2[:-1])
+            exp_index2 = sgn.find_peaks(d, height=0.35 * freq)[0]
+            ins_index2 = sgn.find_peaks(-d, height=0.45 * freq)[0]
 
-                    else:
-                        more_resp_flag = False
-                        k += 1
+            final_flag = False
+            ins_index3 = []
+            exp_index3 = []
+            j_ins = 0
+            j_exp = 0
+            while not final_flag:
+                ins_index3.append(ins_index2[j_ins])
+                while exp_index2[j_exp] < ins_index2[j_ins]:
+                    j_exp += 1
+                    if j_exp == len(exp_index2) - 1:
+                        final_flag = True
+                        break
+                exp_index3.append(exp_index2[j_exp])
+                while ins_index2[j_ins] < exp_index2[j_exp]:
+                    j_ins += 1
+                    if j_ins == len(ins_index2) - 1:
+                        final_flag = True
+                        break
 
-                del_resp.sort()
-                for i in del_resp[::-1]:
-                    resptime = np.delete(resptime, i)
+            resptime = []
+            etco2time = []
+            etco2 = []
+            Th1_list = [5 for i in range(5)]
+            Th2_list = [0.5 for i in range(5)]
+            Th3_list = [0 for i in range(5)]
 
-            elif mode == "threshold":   # Aramendi et al., 2016
-                but = sgn.butter(4, 10 * 2 / freq, btype="lowpass", output="sos")
-                co2 = sgn.sosfiltfilt(but, co)  # Filter forwarsd and backward
-                d = freq * (co2[1:] - co2[:-1])
-                exp_index2 = sgn.find_peaks(d, height=0.35 * freq)[0]
-                ins_index2 = sgn.find_peaks(-d, height=0.45 * freq)[0]
+            k = 0
+            for i_ins, i_exp, i_next_ins in zip(
+                ins_index3[:-1], exp_index3[:-1], ins_index3[1:]
+            ):
+                D = (i_exp - i_ins) / freq
+                A_exp = 1 / (i_next_ins - i_exp) * np.sum(co2[i_exp:i_next_ins])
+                A_ins = 1 / (freq * D) * np.sum(co2[i_ins:i_exp])
+                A_r = (A_exp - A_ins) / A_exp
+                S = 1 / freq * np.sum(co2[i_exp : i_exp + int(freq)])
+                if len(resptime) > 0:
+                    t_ref = pd.Timedelta(
+                        (cotime[i_exp] - resptime[-1])
+                    ).total_seconds()
+                else:
+                    t_ref = 2  # if t_ref >1.5 then it is ok, so 2 does the job
+                if D > 0.3:
+                    if (
+                        A_exp > 0.4 * np.mean(Th1_list)
+                        and A_r > np.min([0.7 * np.mean(Th2_list), 0.5])
+                        and S > 0.4 * np.mean(Th3_list)
+                    ):
+                        if t_ref > 1.5:
+                            resptime.append(cotime[i_exp])
+                            Th1_list[k] = A_exp
+                            Th2_list[k] = A_r
+                            Th3_list[k] = S
+                            etco2time.append(
+                                cotime[i_exp + np.argmax(co2[i_exp:i_next_ins])]
+                            )
+                            etco2.append(np.max(co2[i_exp:i_next_ins]))
+                            k += 1
+                            k = k % 5
+        if mode == "threshold" or mode == "filter":
+            metadata = {
+                "creator": "automatic",
+                "creation_date": pd.Timestamp.now(),
+                "creation_mode": mode,
+            }
+            etco2_lab = Label(
+                "etco2_from_capnography",
+                time_index=etco2time,
+                data=etco2,
+                metadata=metadata,
+                plotstyle=DEFAULT_PLOT_STYLE.get("etco2_from_capnography", None),
+            )
+            source.attach_label(etco2_lab)
 
-                final_flag = False
-                ins_index3 = []
-                exp_index3 = []
-                j_ins = 0
-                j_exp = 0
-                while not final_flag:
-                    ins_index3.append(ins_index2[j_ins])
-                    while exp_index2[j_exp] < ins_index2[j_ins]:
-                        j_exp += 1
-                        if j_exp == len(exp_index2) - 1:
-                            final_flag = True
-                            break
-                    exp_index3.append(exp_index2[j_exp])
-                    while ins_index2[j_ins] < exp_index2[j_exp]:
-                        j_ins += 1
-                        if j_ins == len(ins_index2) - 1:
-                            final_flag = True
-                            break
-
-                resptime = []
-                etco2time = []
-                etco2 = []
-                Th1_list = [5 for i in range(5)]
-                Th2_list = [0.5 for i in range(5)]
-                Th3_list = [0 for i in range(5)]
-
-                k = 0
-                for i_ins, i_exp, i_next_ins in zip(
-                    ins_index3[:-1], exp_index3[:-1], ins_index3[1:]
-                ):
-                    D = (i_exp - i_ins) / freq
-                    A_exp = 1 / (i_next_ins - i_exp) * np.sum(co2[i_exp:i_next_ins])
-                    A_ins = 1 / (freq * D) * np.sum(co2[i_ins:i_exp])
-                    A_r = (A_exp - A_ins) / A_exp
-                    S = 1 / freq * np.sum(co2[i_exp : i_exp + int(freq)])
-                    if len(resptime) > 0:
-                        t_ref = pd.Timedelta(
-                            (cotime[i_exp] - resptime[-1])
-                        ).total_seconds()
-                    else:
-                        t_ref = 2  # if t_ref >1.5 then it is ok, so 2 does the job
-                    if D > 0.3:
-                        if (
-                            A_exp > 0.4 * np.mean(Th1_list)
-                            and A_r > np.min([0.7 * np.mean(Th2_list), 0.5])
-                            and S > 0.4 * np.mean(Th3_list)
-                        ):
-                            if t_ref > 1.5:
-                                resptime.append(cotime[i_exp])
-                                Th1_list[k] = A_exp
-                                Th2_list[k] = A_r
-                                Th3_list[k] = S
-                                etco2time.append(
-                                    cotime[i_exp + np.argmax(co2[i_exp:i_next_ins])]
-                                )
-                                etco2.append(np.max(co2[i_exp:i_next_ins]))
-                                k += 1
-                                k = k % 5
-            if mode == "threshold" or mode == "filter":
-                metadata = {
-                    "creator": "automatic",
-                    "creation_date": pd.Timestamp.now(),
-                    "creation_mode": mode,
-                }
-                etco2_lab = Label(
-                    "etco2_from_capnography",
-                    time_index=etco2time,
-                    data=etco2,
-                    metadata=metadata,
-                    plotstyle=DEFAULT_PLOT_STYLE.get("etco2_from_capnography", None),
-                )
-                co2_channel.attach_label(etco2_lab)
-
-                vent_lab = Label(
-                    "ventilations_from_capnography",
-                    time_index=resptime,
-                    data=None,
-                    metadata=metadata,
-                    plotstyle=DEFAULT_PLOT_STYLE.get(
-                        "ventilations_from_capnography", None
-                    ),
-                )
-                co2_channel.attach_label(vent_lab)
-            else:
-                logger.error(
-                    f"mode {mode} not known. Please use either 'filter' or 'threshold' as argument"
-                )
+            vent_lab = Label(
+                "ventilations_from_capnography",
+                time_index=resptime,
+                data=None,
+                metadata=metadata,
+                plotstyle=DEFAULT_PLOT_STYLE.get(
+                    "ventilations_from_capnography", None
+                ),
+            )
+            source.attach_label(vent_lab)
+        else:
+            logger.error(
+                f"mode {mode} not known. Please use either 'filter' or 'threshold' as argument"
+            )
 
     def cycle_duration_analysis(
             self,
@@ -2031,12 +2036,25 @@ class Vitals:
 
         ACC_channel.attach_label(cc_periods)
 
-    def predict_circulation(self) -> None:
+    def predict_circulation(
+        self,
+        cpr_acceleration_source: Channel | str = "cpr_acceleration",
+        ecg_pads_source: Channel | str = "ecg_pads",
+    ) -> None:
         """Predicts the circulation of a case by using the channels
         'cpr_acceleration' channel and the 'ecg_pads' channel.
 
         The procedure that is used has been published by Kern et al. in `10.1109/TBME.2023.3242717 <https://doi.org/10.1109/TBME.2023.3242717>`_.
         Here 'rosc_decision_function' is the output of the kernelized SVM used in and trained for the paper.
+
+        Parameters
+        ----------
+        cpr_acceleration_source
+            The (name of the) channel containing the accelerometer signal of the CPR
+            feedback sensor. Defaults to ``'cpr_acceleration'``.
+        ecg_pads_source
+            The (name of the) channel containing the ECG signal from the pads.
+            Defaults to ``'ecg_pads'``.
 
         Returns
         -------
@@ -2047,91 +2065,96 @@ class Vitals:
         'rosc_prediction' is the binary prediction.
         """
 
-        if (
-            not (
-                "cpr_acceleration" in self.get_channel_names()
-                and "ecg_pads" in self.get_channel_names()
+        if isinstance(cpr_acceleration_source, str):
+            cpr_acceleration_source = self.get_channel(cpr_acceleration_source)
+
+        if not isinstance(cpr_acceleration_source, Channel):
+            raise ValueError(
+                "No valid accelerometer channel specified. Can not predict circulation. "
+                "Please specify a suitable channel directly or by name."
             )
-            or "cc_depth_cont" in self.get_channel_names()
-        ):
-            logger.error(
-                "WARNING! No Feedback-Sensor-Acceleration or ECG found. Check the presence of these channels in the case."
+        
+        if isinstance(ecg_pads_source, str):
+            ecg_pads_source = self.get_channel(ecg_pads_source)
+
+        if not isinstance(ecg_pads_source, Channel):
+            raise ValueError(
+                "No valid ECG channel specified. Can not predict circulation. "
+                "Please specify a suitable channel directly or by name."
             )
+
+        acc_data = cpr_acceleration_source.get_data()  # get data
+        acctime, acc = acc_data.time_index, acc_data.data
+
+        ecg_data = ecg_pads_source.get_data()  # get data
+        ecgtime, ecg = ecg_data.time_index, ecg_data.data
+
+        if "cc_periods" not in self.get_label_names():
+            self.find_CC_periods_acc(accelerometer_channel=cpr_acceleration_source)
+
+        label_cc_periods = self.data.get_label("cc_periods")
+        cc_periods = label_cc_periods.get_data().time_index
+        cc_periods =  np.asarray([t for pair in cc_periods for t in pair])
+
+        t_ref = cpr_acceleration_source.time_start
+        
+        if label_cc_periods.is_time_relative():
+            cc_periods = pd.Series(pd.to_timedelta(cc_periods)).dt.total_seconds().to_numpy()
         else:
-            ACC_channel = self.data.get_channel("cpr_acceleration")
-            acc_data = ACC_channel.get_data()  # get data
-            acctime, acc = acc_data.time_index, acc_data.data
+            cc_periods = np.array([(t - t_ref).total_seconds() for t in cc_periods])
+        
+        if cpr_acceleration_source.is_time_relative():
+            acctime = acctime.dt.total_seconds().to_numpy()
+        else:
+            acctime = np.array([(t - t_ref).total_seconds() for t in acctime])
 
-            ECG_channel = self.data.get_channel("ecg_pads")
-            ecg_data = ECG_channel.get_data()  # get data
-            ecgtime, ecg = ecg_data.time_index, ecg_data.data
+        # Time conversion for ECG channel
+        if ecg_pads_source.is_time_relative():
+            ecgtime = ecgtime.dt.total_seconds().to_numpy()
+        else:
+            ecgtime = np.array([(t - t_ref).total_seconds() for t in ecgtime])
+        
+        CC_starts = cc_periods[0::2]
+        CC_stops = cc_periods[1::2]
 
-            if "cc_periods" not in self.get_label_names():
-                self.find_CC_periods_acc()
- 
-            label_cc_periods = self.data.get_label("cc_periods")
-            cc_periods = label_cc_periods.get_data().time_index
-            cc_periods =  np.asarray([t for pair in cc_periods for t in pair])
+        snippets = construct_snippets(
+            acctime, acc, ecgtime, ecg, CC_starts, CC_stops
+        )
+        case_pred = predict_circulation(snippets)
 
-            t_ref = ACC_channel.time_start
-            
-            if label_cc_periods.is_time_relative():
-                cc_periods = pd.Series(pd.to_timedelta(cc_periods)).dt.total_seconds().to_numpy()
-            else:
-                cc_periods = np.array([(t - t_ref).total_seconds() for t in cc_periods])
-            
-            if ACC_channel.is_time_relative():
-                acctime = acctime.dt.total_seconds().to_numpy()
-            else:
-                acctime = np.array([(t - t_ref).total_seconds() for t in acctime])
-
-            # Time conversion for ECG channel
-            if ECG_channel.is_time_relative():
-                ecgtime = ecgtime.dt.total_seconds().to_numpy()
-            else:
-                ecgtime = np.array([(t - t_ref).total_seconds() for t in ecgtime])
-            
-            CC_starts = cc_periods[0::2]
-            CC_stops = cc_periods[1::2]
-
-            snippets = construct_snippets(
-                acctime, acc, ecgtime, ecg, CC_starts, CC_stops
-            )
-            case_pred = predict_circulation(snippets)
-
-            metadata = {
-                "creator": "automatic",
-                "creation_date": pd.Timestamp.now(),
-                "method": "Period_dection",
-            }
+        metadata = {
+            "creator": "automatic",
+            "creation_date": pd.Timestamp.now(),
+            "method": "Period_dection",
+        }
 
 
-            pred_lab = Label(
-                "rosc_prediction",
-                case_pred["Starttime"],
-                case_pred["Predicted"],
-                time_start=t_ref,
-                metadata=metadata,
-                plotstyle=DEFAULT_PLOT_STYLE.get("rosc_prediction", None),
-            )
-            prob_lab = Label(
-                "rosc_probability",
-                case_pred["Starttime"],
-                case_pred["Probability"],
-                time_start=t_ref,
-                metadata=metadata,
-                plotstyle=DEFAULT_PLOT_STYLE.get("rosc_probability", None),
-            )
-            dec_lab = Label(
-                "rosc_decision_function",
-                case_pred["Starttime"],
-                case_pred["DecisionFunction"],
-                time_start=t_ref,
-                metadata=metadata,
-                plotstyle=DEFAULT_PLOT_STYLE.get("rosc_decision_function", None),
-            )
-            for lab in [pred_lab, prob_lab, dec_lab]:
-                self.data.add_global_label(lab)
+        pred_lab = Label(
+            "rosc_prediction",
+            case_pred["Starttime"],
+            case_pred["Predicted"],
+            time_start=t_ref,
+            metadata=metadata,
+            plotstyle=DEFAULT_PLOT_STYLE.get("rosc_prediction", None),
+        )
+        prob_lab = Label(
+            "rosc_probability",
+            case_pred["Starttime"],
+            case_pred["Probability"],
+            time_start=t_ref,
+            metadata=metadata,
+            plotstyle=DEFAULT_PLOT_STYLE.get("rosc_probability", None),
+        )
+        dec_lab = Label(
+            "rosc_decision_function",
+            case_pred["Starttime"],
+            case_pred["DecisionFunction"],
+            time_start=t_ref,
+            metadata=metadata,
+            plotstyle=DEFAULT_PLOT_STYLE.get("rosc_decision_function", None),
+        )
+        for lab in [pred_lab, prob_lab, dec_lab]:
+            self.data.add_global_label(lab)
 
 
     def make_cprdat_analysis(self,model='') -> dict:

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -993,20 +993,16 @@ def test_real_evaluation(vitabel_example_data_dir):
 
 def test_analysis_exception_for_missing_data(caplog):
     cardio_recording = Vitals()
-    cardio_recording.compute_etco2_and_ventilations()
+    with pytest.raises(ValueError, match="Channel specification was ambiguous"):
+        cardio_recording.compute_etco2_and_ventilations()
     with pytest.raises(ValueError, match="Channel specification was ambiguous"):
         cardio_recording.find_CC_periods_acc()
     with pytest.raises(ValueError, match="Could not identify channels with single chest compressions."):
         cardio_recording.cycle_duration_analysis()
-    cardio_recording.predict_circulation()
+    with pytest.raises(ValueError, match="Channel specification was ambiguous"):
+        cardio_recording.predict_circulation()
+
     assert len(cardio_recording.labels) == 0
-    assert all(
-        warning in caplog.text
-        for warning in [
-            "No Capnography Signal found.",
-            "No Feedback-Sensor-Acceleration or ECG found.",
-        ]
-    )
 
 
 def test_area_under_threshold_computation():


### PR DESCRIPTION
This PR changes `compute_etco2_and_ventilations` and `predict_circulation` such that...

- proper exceptions are raised instead of `logger.error` calls,
- and the channels whose data is used in these methods are now configurable; they can be specified by name or by `Channel` object