### PR TITLE
Feature: allow querying channels / labels by their index

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -2508,7 +2508,7 @@ class TimeDataCollection:
             channel for channel in self.channels if match_object(channel, **kwargs)
         ]
 
-    def get_channel(self, name: str | None = None, **kwargs) -> Channel:
+    def get_channel(self, name: str | int | None = None, **kwargs) -> Channel:
         """Return a channel by name.
 
         Raises an error if no unique channel is found.
@@ -2517,11 +2517,15 @@ class TimeDataCollection:
         ----------
         name
             The name of the channel to retrieve. Allowed to be passed
-            either as a positional or a keyword argument.
+            either as a positional or a keyword argument. If an integer
+            is passed, it is interpreted as the index of the channel
+            in the collection.
         kwargs
             Keyword arguments to filter the channels by.
         """
         if name is not None:
+            if isinstance(name, int):
+                return self.channels[name]
             kwargs["name"] = name
         channels = self.get_channels(**kwargs)
         if len(channels) != 1:
@@ -2556,7 +2560,7 @@ class TimeDataCollection:
             kwargs["name"] = name
         return [label for label in self.labels if match_object(label, **kwargs)]
 
-    def get_label(self, name: str | None = None, **kwargs) -> Label:
+    def get_label(self, name: str | int | None = None, **kwargs) -> Label:
         """Return a label by name.
 
         Raises an error if no unique label is found.
@@ -2565,13 +2569,17 @@ class TimeDataCollection:
         ----------
         name
             The name of the label to retrieve. Allowed to be passed
-            either as a positional or a keyword argument.
+            either as a positional or a keyword argument. If an integer
+            is passed, it is interpreted as the index of the label
+            in the collection.
         kwargs
             Keyword arguments to filter the labels by. The
             specified arguments are compared to the attributes
             of the labels.
         """
         if name is not None:
+            if isinstance(name, int):
+                return self.labels[name]
             kwargs["name"] = name
         labels = self.get_labels(**kwargs)
         if len(labels) != 1:

--- a/src/vitabel/vitals.py
+++ b/src/vitabel/vitals.py
@@ -936,21 +936,23 @@ class Vitals:
         """
         return self.data.get_channels(name, **kwargs)
 
-    def get_channel(self, name: str | None = None, **kwargs) -> Channel:
+    def get_channel(self, name: str | int | None = None, **kwargs) -> Channel:
         """Returns a single channel based on its name.
 
         Parameters
         ----------
         name
-            The name of the channel to retrieve.
+            The name of the channel to retrieve. If an integer is passed,
+            it is interpreted as the index of the channel in the list of
+            all channels.
         kwargs
             Keyword arguments to filter the channels by.
 
         Raises
         ------
         ValueError
-            If the specification is ambiguous, i.e., if more than one channel
-            matches the specification.
+            If the specification is ambiguous, i.e., if more than one or
+            no channel matches the specification.
 
         Returns
         -------
@@ -965,7 +967,7 @@ class Vitals:
         
         Parameters
         ----------
-        name : str
+        name
             The name of the labels to retrieve.
         label_type : TYPE, optional
             A specification of the label type (IntervalLabel or Label) to retrieve
@@ -983,14 +985,15 @@ class Vitals:
             return [label for label in self.get_labels(name) if type(label) is label_type]
         return self.data.get_labels(name, **kwargs)
 
-    def get_label(self, name: str | None = None, **kwargs) -> Label:
+    def get_label(self, name: str | int | None = None, **kwargs) -> Label:
         """Return a list of labels.
 
         Parameters
         ----------
         name
             The name of the label to retrieve. Allowed to be passed
-            either as a positional or a keyword argument.
+            either as a positional or a keyword argument. If ``name`` is an integer,
+            it is interpreted as the index of the label in the list of all labels.
         kwargs
             Keyword arguments to filter the labels by. The
             specified arguments are compared to the attributes

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -920,6 +920,8 @@ def test_get_label():
 
     collection = TimeDataCollection(channels=[channel], labels=[label])
     assert collection.get_label(name="events") == label
+    assert collection.get_label(name=0) == label
+    assert collection.get_label(name=1) == label2
 
     with pytest.raises(ValueError, match="ambiguous"):
         assert collection.get_label(name="nonexistent")


### PR DESCRIPTION
This patches `get_channel` and `get_label` to also accept integers, which are then interpreted as the respective index in the list of all channels or the list of all labels.

Note: the plural versions of these methods (`get_channels`, `get_labels`) do **not** support the index syntax (because it doesn't really make sense there, I feel).