### PR TITLE
fix: handle non-resuscitation recordings in read_zollcsv

### DIFF
--- a/src/vitabel/utils/loading.py
+++ b/src/vitabel/utils/loading.py
@@ -1904,8 +1904,15 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
             nonz1 = nonz[0]
             nonz2 = nonz[-1]
         except IndexError:
-            nonz1 = 0
-            nonz2 = -1
+            # Channel exists in the recording but contains only zeros (e.g. a lead
+            # that was connected but not actively recording). Store it as an empty
+            # DataFrame so downstream code can detect its presence without carrying
+            # a large array of meaningless zeros.
+            newname = new_names(key)
+            df = pd.DataFrame(columns=pd.Index([newname]))
+            df.index.name = "timestamp"
+            data[newname] = df
+            continue
         series = series[nonz1:nonz2]
         timestamps1 = timestamps1[nonz1:nonz2]
         newname = new_names(key)
@@ -1924,8 +1931,15 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
             nonz1 = nonz[0]
             nonz2 = nonz[-1]
         except IndexError:
-            nonz1 = 0
-            nonz2 = -1
+            # Channel exists in the recording but contains only zeros (e.g. a lead
+            # that was connected but not actively recording). Store it as an empty
+            # DataFrame so downstream code can detect its presence without carrying
+            # a large array of meaningless zeros.
+            newname = new_names(key)
+            df = pd.DataFrame(columns=pd.Index([newname]))
+            df.index.name = "timestamp"
+            data[newname] = df
+            continue
         series = series[nonz1:nonz2]
         timestamps1 = timestamps1[nonz1:nonz2]
 

--- a/src/vitabel/utils/loading.py
+++ b/src/vitabel/utils/loading.py
@@ -1942,6 +1942,8 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
         series = np.array(a[key])
         timestamps1 = timestamps[series != 0]
         series = series[series != 0]
+        if len(timestamps1) == 0:
+            continue
         no_double_entries = (
             pd.Series(timestamps1[1:] - timestamps1[:-1]).dt.total_seconds() > 0.01
         )
@@ -1956,7 +1958,8 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
         df = pd.DataFrame(df)
         df.set_index("timestamp", inplace=True)
         data[newname] = df
-    data["CompDisp"]["CompDisp"] *= 2.54
+    if "CompDisp" in data:
+        data["CompDisp"]["CompDisp"] *= 2.54
 
     pat_dat = {}
 
@@ -1980,12 +1983,16 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
         pat_dat["Keys"]["Unit"][key] = "mV"
 
     for key in ["CompDisp", "CompRate"]:
+        if key not in data:
+            continue
         pat_dat["Keys"]["Type"][key] = "Trend data"
         pat_dat["Keys"]["Start"][key] = data[key].first_valid_index()
         pat_dat["Keys"]["Stop"][key] = data[key].last_valid_index()
         pat_dat["Keys"]["Length"][key] = len(data[key][key])
-    pat_dat["Keys"]["Unit"]["CompDisp"] = "cm"
-    pat_dat["Keys"]["Unit"]["CompRate"] = "1/min"
+    if "CompDisp" in data:
+        pat_dat["Keys"]["Unit"]["CompDisp"] = "cm"
+    if "CompRate" in data:
+        pat_dat["Keys"]["Unit"]["CompRate"] = "1/min"
 
     pat_dat["Keys"] = (
         pd.DataFrame.from_dict(pat_dat["Keys"], orient="columns")

--- a/src/vitabel/utils/loading.py
+++ b/src/vitabel/utils/loading.py
@@ -1904,14 +1904,6 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
             nonz1 = nonz[0]
             nonz2 = nonz[-1]
         except IndexError:
-            # Channel exists in the recording but contains only zeros (e.g. a lead
-            # that was connected but not actively recording). Store it as an empty
-            # DataFrame so downstream code can detect its presence without carrying
-            # a large array of meaningless zeros.
-            newname = new_names(key)
-            df = pd.DataFrame(columns=pd.Index([newname]))
-            df.index.name = "timestamp"
-            data[newname] = df
             continue
         series = series[nonz1:nonz2]
         timestamps1 = timestamps1[nonz1:nonz2]
@@ -1931,14 +1923,6 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
             nonz1 = nonz[0]
             nonz2 = nonz[-1]
         except IndexError:
-            # Channel exists in the recording but contains only zeros (e.g. a lead
-            # that was connected but not actively recording). Store it as an empty
-            # DataFrame so downstream code can detect its presence without carrying
-            # a large array of meaningless zeros.
-            newname = new_names(key)
-            df = pd.DataFrame(columns=pd.Index([newname]))
-            df.index.name = "timestamp"
-            data[newname] = df
             continue
         series = series[nonz1:nonz2]
         timestamps1 = timestamps1[nonz1:nonz2]
@@ -1987,14 +1971,16 @@ def read_zollcsv(filepath: Path | str, filepathxml: Path | str, quick=False):
         pat_dat["Keys"]["Start"][key] = data[key].first_valid_index()
         pat_dat["Keys"]["Stop"][key] = data[key].last_valid_index()
         pat_dat["Keys"]["Length"][key] = len(data[key][key])
-    pat_dat["Keys"]["Unit"]["Displacement"] = "inch"
+    if "Displacement" in data:
+        pat_dat["Keys"]["Unit"]["Displacement"] = "inch"
     for key in [
         "Pads",
         " Ecg2Val",
         " Ecg3Val",
         " Ecg4Val",
     ]:  #### !!!!!! 08.04. ,'Filtered ECG' entfernt
-        pat_dat["Keys"]["Unit"][key] = "mV"
+        if key in data:
+            pat_dat["Keys"]["Unit"][key] = "mV"
 
     for key in ["CompDisp", "CompRate"]:
         if key not in data:

--- a/tests/test_vitals.py
+++ b/tests/test_vitals.py
@@ -12,6 +12,7 @@ import pytest
 
 from vitabel import Vitals, __version__
 from vitabel import Channel, Label, IntervalLabel
+from vitabel.utils import loading
 
 
 def compare_two_dictionaries(dict1, dict2):
@@ -56,6 +57,57 @@ def _write_test_edfplus(path: Path):
     writer.writeAnnotation(5.0, 1.0, "artifact")
     writer.writeAnnotation(8.0, 0.5, "noise")
     writer.close()
+
+
+def _write_synthetic_zoll_csv_pair(base_path: Path) -> tuple[Path, Path]:
+    csv_path = base_path.with_name(base_path.name + "_ecg.txt")
+    xml_path = base_path.with_suffix(".xml")
+
+    rows = []
+    for i in range(3):
+        rows.append(
+            {
+                "Start": 0,
+                " Serial": "AR12345",
+                " DeviceId": 1,
+                " RunNumber": 1,
+                " Date": " 01-01-2024",
+                " Real": f" 12:00:0{i}.000",
+                " Elapsed": i,
+                " X": 0,
+                " EcgVal": i + 1,
+                " EcgStatus": 1,
+                " CapnoVal": 10 + i,
+                " CapnoStatus": 1,
+                " P1Val": 0,
+                " P1Status": 0,
+                " P2Val": 0,
+                " P2Status": 0,
+                " P3Val": 0,
+                " P3Status": 0,
+                " Spo2Val": 95 + i,
+                " Spo2Status": 1,
+                " CprDepth": 0,
+                " CprFrequency": 0,
+                " CprStatus": 0,
+                " CprWaveVal": 0,
+                " FiltEcgVal": 0,
+                " FiltEcgStatus": 0,
+                " Ecg2Val": 0,
+                " Ecg2Status": 0,
+                " Ecg3Val": 0,
+                " Ecg3Status": 0,
+                " Ecg4Val": 0,
+                " Ecg4Status": 0,
+            }
+        )
+
+    pd.DataFrame(rows).to_csv(csv_path, index=False, encoding="utf-16")
+    xml_path.write_text(
+        "<Root><Record><Defibrillator><Serial>AR12345</Serial></Defibrillator></Record></Root>",
+        encoding="utf-8",
+    )
+    return csv_path, xml_path
 
 
 def test_cardio_init():
@@ -157,6 +209,30 @@ def test_add_zoll_json(vitabel_example_data_dir):
 #     cardio_recording.add_defibrillator_recording(file_path)
 #     check_cardio_properties(cardio_recording)
 #     assert cardio_recording.channels
+
+
+def test_read_zoll_csv_without_cpr_data(tmp_path):
+    csv_path, xml_path = _write_synthetic_zoll_csv_pair(tmp_path / "zoll_case")
+
+    pat_dat, data = loading.read_zollcsv(csv_path, xml_path)
+
+    assert "Pads" in data
+    assert "CO2 mmHg, Waveform" in data
+    assert "SpO2 %, Waveform" in data
+    assert "CompDisp" not in data
+    assert "CompRate" not in data
+    assert "Displacement" not in data
+    assert "CompDisp" not in pat_dat["Keys"]["Key"].values
+    assert "CompRate" not in pat_dat["Keys"]["Key"].values
+    assert "Displacement" not in pat_dat["Keys"]["Key"].values
+
+    cardio_recording = Vitals()
+    cardio_recording.add_defibrillator_recording(csv_path)
+    assert sorted(cardio_recording.get_channel_names()) == [
+        "capnography",
+        "ecg_pads",
+        "ppg",
+    ]
 
 
 def test_add_stryker_lucas(vitabel_test_data_dir):


### PR DESCRIPTION
When a recording has no CPR activity, CprDepth and CprFrequency columns are all zeros. After filtering out zeros, timestamps1 is empty, causing IndexError on timestamps1[-1] and subsequent KeyError on CompDisp/CompRate accesses that assumed CPR data was always present.
#276 

Additionally omits import of vast zero arrays.

Example File for ZOLL R Series containing ECG an PPG:
[20260331124955_00147042.zip](https://github.com/user-attachments/files/26385323/20260331124955_00147042.zip)
