### PR TITLE
fix: preserve label add_data precision after PR #279

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -1360,9 +1360,7 @@ class Label(TimeSeriesBase):
             time_data = time_data - self.time_start
 
         if isinstance(time_data, Timedelta) and len(self.time_index) > 0:
-            self.time_index = self.time_index.as_unit(
-                np.datetime_data(time_data.to_timedelta64().dtype)[0]
-            )
+            self.time_index = self.time_index.as_unit("ns")
 
         [insert_index] = self.time_index.searchsorted([time_data])
         self.time_index = self.time_index.insert(insert_index, time_data)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -630,6 +630,30 @@ def test_label_relative_time_add_remove_data():
         label.remove_data(pd.to_timedelta(999, unit="s"))
 
 
+def test_label_add_data_preserves_subsecond_precision_for_second_based_labels():
+    label = Label(name="events", time_index=[0, 2], time_unit="s")
+
+    label.add_data(pd.to_timedelta(1.5, unit="s"))
+
+    np.testing.assert_array_equal(label.time_index.total_seconds(), [0.0, 1.5, 2.0])
+    assert label.time_index.dtype == "timedelta64[ns]"
+
+
+def test_label_add_data_does_not_downcast_existing_high_resolution_index():
+    label = Label(
+        name="events",
+        time_index=pd.to_timedelta([0.123456789, 2.987654321], unit="s"),
+    )
+
+    label.add_data(pd.to_timedelta(1, unit="s"))
+
+    np.testing.assert_array_equal(
+        label.time_index.total_seconds(),
+        [0.123456789, 1.0, 2.987654321],
+    )
+    assert label.time_index.dtype == "timedelta64[ns]"
+
+
 def test_label_absolute_time_add_remove_data():
     label = Label(
         name="events",


### PR DESCRIPTION
Follow-up to #279.

`Label.add_data()` needs a small precision fix: inserting a sub-second `Timedelta` into a label with `timedelta64[s]` index should preserve fractional seconds, but we also must not downcast existing higher-resolution entries.

This keeps the implementation simple by normalizing non-empty label `time_index` values to `timedelta64[ns]` before `searchsorted` / `insert`. It also adds two focused regression tests: one for the original 1.5s case and one to ensure existing ns-precision entries stay intact.

Local validation:
- `uv run pytest tests/test_timeseries.py -q`