### PR TITLE
fix: resolve OutOfBoundsTimedelta in compute_ventilation_volumes #285

### DIFF
--- a/src/vitabel/analysis/ventilation/volumes.py
+++ b/src/vitabel/analysis/ventilation/volumes.py
@@ -545,7 +545,7 @@ def compute_reverse_airflow_labels(
     )
     insp_reverse_airflow = IntervalLabel(
         name="Inspiratory Reverse Airflow",
-        time_index=segment[mask_insp_reverse].tolist(),
+        time_index=segment[mask_insp_reverse],
         data=None,
         metadata={"source": "computed"},
     )
@@ -565,7 +565,7 @@ def compute_reverse_airflow_labels(
     )
     exp_reverse_airflow = IntervalLabel(
         name="Expiratory Reverse Airflow",
-        time_index=segment[mask_exp_reverse].tolist(),
+        time_index=segment[mask_exp_reverse],
         data=None,
         metadata={"source": "computed"},
     )

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -1911,7 +1911,7 @@ class IntervalLabel(Label):
         plot_type: IntervalLabelPlotType = "combined",
         annotation_preset_type: LabelAnnotationPresetType | None = None,
     ):
-        if time_index is not None and len(time_index) > 0:
+        if time_index is not None:
             time_index = np.array(time_index)
             if time_index.ndim == 2 and time_index.shape[1] == 2:
                 # time data passed as pairs of interval end points


### PR DESCRIPTION
## Summary

- Drop `.tolist()` on `datetime64[ns]` arrays in `compute_reverse_airflow_labels`: calling `.tolist()` converted each element to a Python `int` (nanoseconds since epoch), which `TimeSeriesBase.__init__` then misinterpreted as seconds, overflowing `timedelta64[ns]`.
- Remove the `len > 0` guard in `IntervalLabel.__init__`: empty `(0, 2)` arrays (no reverse airflow intervals present) were bypassing the 2D→1D reshape and reaching `pd.to_timedelta` as a 2D array, which it rejects with `TypeError`.

## Test plan

- [x] Existing test `TestComputeVentilationVolumes::test_compute_ventilation_volumes_basic_outputs` now passes (was failing before this fix)
- [x] Full test suite passes (`153 passed`)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)