### PR TITLE
fix: raise ValueError for non-1D data array in Channel.__init__

### DIFF
--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -165,6 +165,12 @@ class TimeSeriesBase:
         # it is possible that the specified time_index is empty
         # or contains undefined values like pandas.NaT, numpy.nan, or None.
 
+        time_index_arr = np.asarray(time_index)
+        if time_index_arr.ndim != 1:
+            raise ValueError(
+                f"time_index must be a 1D array, got shape {time_index_arr.shape}"
+            )
+
         cleaned_time_index_iter = (value for value in time_index if not pd.isna(value))
 
         try:
@@ -1087,9 +1093,17 @@ class Label(TimeSeriesBase):
             else:
                 # replace None with np.nan and convert to float
                 data = np.asarray(data, dtype=float)
+                if data.ndim != 1:
+                    raise ValueError(
+                        f"data must be a 1D array, got shape {data.shape}"
+                    )
 
         if text_data is not None and len(text_data) > 0:
             text_data = np.asarray(text_data, dtype=object)
+            if text_data.ndim != 1:
+                raise ValueError(
+                    f"text_data must be a 1D array, got shape {text_data.shape}"
+                )
             text_data[text_data == ""] = None
         else:
             text_data = None

--- a/src/vitabel/timeseries.py
+++ b/src/vitabel/timeseries.py
@@ -581,6 +581,11 @@ class Channel(TimeSeriesBase):
         if data is not None:
             if not isinstance(data, np.ndarray):
                 data = np.asarray(data)
+            
+            if data.ndim != 1:
+                raise ValueError(
+                    f"data must be a 1D array, got shape {data.shape}"
+                )
 
             if len(data) != len(time_index):
                 raise ValueError(

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -272,6 +272,13 @@ def test_channel_creation():
     assert channel.data.shape == (10,)
 
 
+def test_channel_creation_2d_data_raises():
+    time = np.arange(5, dtype=float)
+    data_2d = np.zeros((5, 5))
+    with pytest.raises(ValueError, match="1D array"):
+        Channel(name="test", time_index=time, data=data_2d)
+
+
 def test_channel_creation_data_from_list():
     time = [0, 0.12, 3.17, 6.42]
     data = [1, 2, 3, 4.5]

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -274,9 +274,10 @@ def test_channel_creation():
 
 def test_channel_creation_2d_data_raises():
     time = np.arange(5, dtype=float)
-    data_2d = np.zeros((5, 5))
     with pytest.raises(ValueError, match="1D array"):
-        Channel(name="test", time_index=time, data=data_2d)
+        Channel(name="test", time_index=time, data=np.zeros((5, 5)))
+    with pytest.raises(ValueError, match="1D array"):
+        Channel(name="test", time_index=np.zeros((5, 5)))
 
 
 def test_channel_creation_data_from_list():
@@ -551,6 +552,16 @@ def test_label_creation_errors():
         match="length of the data must be equal to the length of the time index",
     ):
         Label(name="test", time_index=[0, 5, 12], data=[None, None])
+
+
+def test_label_creation_2d_raises():
+    time = np.arange(5, dtype=float)
+    with pytest.raises(ValueError, match="1D array"):
+        Label(name="test", time_index=time, data=np.zeros((5, 2)))
+    with pytest.raises(ValueError, match="1D array"):
+        Label(name="test", time_index=time, text_data=np.empty((5, 2), dtype=object))
+    with pytest.raises(ValueError, match="1D array"):
+        Label(name="test", time_index=np.zeros((5, 2)))
 
 
 def test_label_attached_to_channel():


### PR DESCRIPTION
Closes #287.

Adds `ndim != 1` guards to prevent 2D+ arrays from silently passing `len()`-based length checks:

- `Channel.__init__` — `data` (extended with test for 2D `time_index`)
- `TimeSeriesBase.__init__` — `time_index` (new)
- `Label.__init__` — `data` and `text_data` (new)

`IntervalLabel` is unaffected: it reshapes an `(m, 2)` `time_index` to 1D before the parent `__init__` is called, so the new guard never trips for valid interval input.

## Test plan

- [x] `test_channel_creation_2d_data_raises` — 2D `data` and 2D `time_index` on `Channel` raise `ValueError`
- [x] `test_label_creation_2d_raises` — 2D `data`, `text_data`, and `time_index` on `Label` raise `ValueError`
- [x] Full test suite (71 tests) — no regressions
